### PR TITLE
ci: register release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,5 @@
 name: "Release"
+run-name: "Release from ${{ github.ref_name }}"
 
 on: workflow_dispatch
 


### PR DESCRIPTION
Give manual release runs a stable display name so GitHub indexes the release workflow in the new public repository.