### PR TITLE
fix: smooth permission and update checks

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -723,8 +723,8 @@ fn apply_runtime_settings(
 }
 
 #[tauri::command]
-fn check_for_updates(app: AppHandle) {
-    spawn_update_check(app, true);
+async fn check_for_updates(app: AppHandle) {
+    run_update_check(app, true).await;
 }
 
 #[tauri::command]
@@ -4464,64 +4464,74 @@ fn find_cli_binary(name: &str) -> Result<PathBuf, String> {
 /// item passes `true`, because a user who asked deserves an answer either way. Updates
 /// are only offered, never applied unattended.
 pub(crate) fn spawn_update_check(app: tauri::AppHandle, notify_when_current: bool) {
-    tauri::async_runtime::spawn(async move {
-        let report = |body: String| {
-            if notify_when_current {
-                app.dialog()
-                    .message(body)
-                    .title("Savvy Updates")
-                    .show(|_| {});
-            }
-        };
-        let updater = match app.updater() {
-            Ok(updater) => updater,
-            Err(error) => {
-                log::warn!("updater is unavailable: {error}");
-                report(format!("Could not check for updates: {error}"));
+    tauri::async_runtime::spawn(run_update_check(app, notify_when_current));
+}
+
+async fn run_update_check(app: tauri::AppHandle, notify_when_current: bool) {
+    let report = |body: String| {
+        if notify_when_current {
+            app.dialog()
+                .message(body)
+                .title("Savvy Updates")
+                .show(|_| {});
+        }
+    };
+    let updater = match app.updater() {
+        Ok(updater) => updater,
+        Err(error) => {
+            log::warn!("updater is unavailable: {error}");
+            report(format!("Could not check for updates: {error}"));
+            return;
+        }
+    };
+    let update = match updater.check().await {
+        Ok(Some(update)) => update,
+        Ok(None) => {
+            report(format!(
+                "Savvy {} is the latest version.",
+                app.package_info().version
+            ));
+            return;
+        }
+        Err(error) => {
+            log::info!("update check did not complete: {error}");
+            report(update_check_error_message(&error));
+            return;
+        }
+    };
+    let version = update.version.clone();
+    let handle = app.clone();
+    app.dialog()
+        .message(format!(
+            "Savvy {version} is available. Install it and restart now?"
+        ))
+        .title("Update available")
+        .buttons(MessageDialogButtons::OkCancelCustom(
+            "Install and restart".into(),
+            "Later".into(),
+        ))
+        // Installing from inside the callback keeps the whole flow on the async
+        // runtime without a channel; `tokio` is a macOS-only dependency here.
+        .show(move |accepted| {
+            if !accepted {
                 return;
             }
-        };
-        let update = match updater.check().await {
-            Ok(Some(update)) => update,
-            Ok(None) => {
-                report(format!(
-                    "Savvy {} is the latest version.",
-                    app.package_info().version
-                ));
-                return;
-            }
-            Err(error) => {
-                log::info!("update check did not complete: {error}");
-                report(format!("Could not check for updates: {error}"));
-                return;
-            }
-        };
-        let version = update.version.clone();
-        let handle = app.clone();
-        app.dialog()
-            .message(format!(
-                "Savvy {version} is available. Install it and restart now?"
-            ))
-            .title("Update available")
-            .buttons(MessageDialogButtons::OkCancelCustom(
-                "Install and restart".into(),
-                "Later".into(),
-            ))
-            // Installing from inside the callback keeps the whole flow on the async
-            // runtime without a channel; `tokio` is a macOS-only dependency here.
-            .show(move |accepted| {
-                if !accepted {
+            tauri::async_runtime::spawn(async move {
+                if let Err(error) = update.download_and_install(|_, _| {}, || {}).await {
+                    log::error!("could not install update {version}: {error}");
                     return;
                 }
-                tauri::async_runtime::spawn(async move {
-                    if let Err(error) = update.download_and_install(|_, _| {}, || {}).await {
-                        log::error!("could not install update {version}: {error}");
-                        return;
-                    }
-                    handle.restart();
-                });
+                handle.restart();
             });
-    });
+        });
+}
+
+fn update_check_error_message(error: &tauri_plugin_updater::Error) -> String {
+    if matches!(error, tauri_plugin_updater::Error::ReleaseNotFound) {
+        "No published Savvy updates are available yet.".into()
+    } else {
+        format!("Could not check for updates: {error}")
+    }
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -5398,5 +5408,13 @@ mod tests {
             message: "not authenticated".into(),
         }];
         assert!(choose_healthy_provider("codex", &providers).is_err());
+    }
+
+    #[test]
+    fn missing_update_manifest_is_not_reported_as_an_error() {
+        assert_eq!(
+            update_check_error_message(&tauri_plugin_updater::Error::ReleaseNotFound),
+            "No published Savvy updates are available yet."
+        );
     }
 }

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -126,17 +126,21 @@ describe("App", () => {
     ).toEqual([final.text, "working correctly"]);
   });
 
-  it("waits for a permission prompt to close before checking the result", async () => {
-    const check = vi.fn().mockResolvedValue(false);
-    const result = requestPermissionDecision(async () => {
-      window.dispatchEvent(new Event("blur"));
-    }, check);
+  it("polls until macOS reports a permission grant", async () => {
+    vi.useFakeTimers();
+    try {
+      const check = vi
+        .fn<() => Promise<boolean>>()
+        .mockResolvedValueOnce(false)
+        .mockResolvedValueOnce(true);
+      const result = requestPermissionDecision(vi.fn(), check);
 
-    await new Promise((resolve) => window.setTimeout(resolve, 300));
-    expect(check).not.toHaveBeenCalled();
-    window.dispatchEvent(new Event("focus"));
-    await expect(result).resolves.toBe(false);
-    expect(check).toHaveBeenCalledOnce();
+      await vi.advanceTimersByTimeAsync(500);
+      await expect(result).resolves.toBe(true);
+      expect(check).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("shows one grounded preparation workspace", async () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3447,6 +3447,18 @@ function AppFooter({
   saving: boolean;
   onSave: (patch: Partial<AppSettings>) => Promise<boolean>;
 }) {
+  const [checkingForUpdates, setCheckingForUpdates] = useState(false);
+
+  async function handleUpdateCheck() {
+    if (checkingForUpdates) return;
+    setCheckingForUpdates(true);
+    try {
+      await checkForUpdates();
+    } finally {
+      setCheckingForUpdates(false);
+    }
+  }
+
   return (
     <footer className="app-footer">
       {settings ? (
@@ -3478,8 +3490,12 @@ function AppFooter({
         </span>
       )}
       <span className="footer-update">
-        <button type="button" onClick={() => void checkForUpdates()}>
-          Check for updates
+        <button
+          type="button"
+          disabled={checkingForUpdates}
+          onClick={() => void handleUpdateCheck()}
+        >
+          {checkingForUpdates ? "Checking…" : "Check for updates"}
         </button>
         <span>•</span>
         <span>v{version}</span>

--- a/src/Onboarding.tsx
+++ b/src/Onboarding.tsx
@@ -10,10 +10,7 @@ import type { TranscriptionKeyStatus } from "./types";
 
 type Step = "permissions" | "transcription";
 
-type Permission = {
-  granted: boolean;
-  checking: boolean;
-};
+type PermissionStatus = "checking" | "needed" | "waiting" | "granted";
 
 const PROVIDERS = [
   { id: "deepgram", label: "Deepgram", keyUrl: "https://console.deepgram.com" },
@@ -75,14 +72,8 @@ export default function Onboarding({
 }) {
   const [step, setStep] = useState<Step>("permissions");
   const [isMacos, setIsMacos] = useState(false);
-  const [microphone, setMicrophone] = useState<Permission>({
-    granted: false,
-    checking: true,
-  });
-  const [screen, setScreen] = useState<Permission>({
-    granted: false,
-    checking: true,
-  });
+  const [microphone, setMicrophone] = useState<PermissionStatus>("checking");
+  const [screen, setScreen] = useState<PermissionStatus>("checking");
   const [provider, setProvider] = useState<ProviderId>("deepgram");
   const [apiKey, setApiKey] = useState("");
   const [keyStatus, setKeyStatus] = useState<TranscriptionKeyStatus>({
@@ -95,16 +86,18 @@ export default function Onboarding({
   const applyPermissions = useCallback(
     ({ macos, mic, capture }: PermissionReading) => {
       setIsMacos(macos);
-      setMicrophone({ granted: mic, checking: false });
-      setScreen({ granted: capture, checking: false });
+      setMicrophone(mic ? "granted" : "needed");
+      setScreen(capture ? "granted" : "needed");
     },
     [],
   );
 
-  const refreshPermissions = useCallback(
-    () => readPermissions().then(applyPermissions),
-    [applyPermissions],
-  );
+  const refreshPermissions = useCallback(async () => {
+    setError(null);
+    setMicrophone("checking");
+    setScreen("checking");
+    applyPermissions(await readPermissions());
+  }, [applyPermissions]);
 
   useEffect(() => {
     void readPermissions().then(applyPermissions);
@@ -119,33 +112,45 @@ export default function Onboarding({
 
   async function grantMicrophone() {
     setError(null);
-    const { checkMicrophonePermission, requestMicrophonePermission } =
-      await macosPermissions();
-    const granted = await requestPermissionDecision(
-      requestMicrophonePermission,
-      checkMicrophonePermission,
-    );
-    setMicrophone({ granted, checking: false });
-    if (!granted) {
+    setMicrophone("waiting");
+    try {
+      const { checkMicrophonePermission, requestMicrophonePermission } =
+        await macosPermissions();
+      const granted = await requestPermissionDecision(
+        requestMicrophonePermission,
+        checkMicrophonePermission,
+      );
+      setMicrophone(granted ? "granted" : "needed");
+      if (granted) return;
       setError(
         "Allow Savvy microphone access in System Settings, then check again.",
       );
+    } catch {
+      setMicrophone("needed");
+      setError("Savvy could not request microphone access. Try again.");
     }
   }
 
   async function grantScreenRecording() {
     setError(null);
-    const { checkScreenRecordingPermission, requestScreenRecordingPermission } =
-      await macosPermissions();
-    const granted = await requestPermissionDecision(
-      requestScreenRecordingPermission,
-      checkScreenRecordingPermission,
-    );
-    setScreen({ granted, checking: false });
-    if (!granted) {
+    setScreen("waiting");
+    try {
+      const {
+        checkScreenRecordingPermission,
+        requestScreenRecordingPermission,
+      } = await macosPermissions();
+      const granted = await requestPermissionDecision(
+        requestScreenRecordingPermission,
+        checkScreenRecordingPermission,
+      );
+      setScreen(granted ? "granted" : "needed");
+      if (granted) return;
       setError(
         "Allow Savvy screen recording in System Settings, then check again. macOS may ask you to reopen Savvy.",
       );
+    } catch {
+      setScreen("needed");
+      setError("Savvy could not request screen recording access. Try again.");
     }
   }
 
@@ -178,8 +183,7 @@ export default function Onboarding({
           icon={Mic}
           title="Microphone"
           detail="Transcribes your side of the meeting."
-          granted={microphone.granted}
-          checking={microphone.checking}
+          status={microphone}
           onGrant={grantMicrophone}
           disabled={!isMacos}
         />
@@ -187,8 +191,7 @@ export default function Onboarding({
           icon={MonitorPlay}
           title="Screen &amp; system audio"
           detail="Transcribes everyone else in an online meeting."
-          granted={screen.granted}
-          checking={screen.checking}
+          status={screen}
           onGrant={grantScreenRecording}
           disabled={!isMacos}
         />
@@ -202,7 +205,7 @@ export default function Onboarding({
           </button>
           <button
             className="button"
-            disabled={!microphone.granted}
+            disabled={microphone !== "granted"}
             onClick={() =>
               returningUser ? onComplete() : setStep("transcription")
             }
@@ -210,7 +213,7 @@ export default function Onboarding({
             Continue
           </button>
         </div>
-        {!screen.granted && microphone.granted && (
+        {screen !== "granted" && microphone === "granted" && (
           <p className="onboarding-note">
             Without screen &amp; system audio, Savvy only hears you — not the
             people you are meeting.
@@ -302,16 +305,14 @@ function PermissionRow({
   icon: Icon,
   title,
   detail,
-  granted,
-  checking,
+  status,
   disabled,
   onGrant,
 }: {
   icon: typeof Mic;
   title: string;
   detail: string;
-  granted: boolean;
-  checking: boolean;
+  status: PermissionStatus;
   disabled: boolean;
   onGrant: () => Promise<void>;
 }) {
@@ -324,17 +325,21 @@ function PermissionRow({
         <strong>{title}</strong>
         <small>{detail}</small>
       </span>
-      {granted ? (
+      {status === "granted" ? (
         <span className="onboarding-granted">
           <Check /> Allowed
         </span>
       ) : (
         <button
           className="button secondary"
-          disabled={checking || disabled}
+          disabled={status === "checking" || status === "waiting" || disabled}
           onClick={() => void onGrant()}
         >
-          {checking ? "Checking…" : "Allow"}
+          {status === "checking"
+            ? "Checking…"
+            : status === "waiting"
+              ? "Waiting…"
+              : "Allow"}
         </button>
       )}
     </div>

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -2,28 +2,12 @@ export async function requestPermissionDecision(
   request: () => Promise<unknown>,
   check: () => Promise<boolean>,
 ) {
-  let promptOpened = false;
-  let finishWaiting = () => {};
-  const promptClosed = new Promise<void>((resolve) => {
-    finishWaiting = resolve;
-  });
-  const onBlur = () => {
-    promptOpened = true;
-  };
-  const onFocus = () => {
-    if (promptOpened) finishWaiting();
-  };
-  const initiallyFocused = document.hasFocus();
-  window.addEventListener("blur", onBlur);
-  window.addEventListener("focus", onFocus);
-  try {
-    await request();
-    await new Promise((resolve) => window.setTimeout(resolve, 250));
-    if (initiallyFocused && !document.hasFocus()) promptOpened = true;
-    if (promptOpened) await promptClosed;
-    return check();
-  } finally {
-    window.removeEventListener("blur", onBlur);
-    window.removeEventListener("focus", onFocus);
+  await request();
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    if (await check()) return true;
+    if (attempt < 19) {
+      await new Promise((resolve) => window.setTimeout(resolve, 500));
+    }
   }
+  return false;
 }


### PR DESCRIPTION
## Summary
- wait for macOS permission state instead of relying on focus events
- show clear checking and waiting states during onboarding
- await manual update checks and explain when no published release exists

## Verification
- pnpm verify