### PR TITLE
fix: keep setup responsive while permissions are granted

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -2383,8 +2383,37 @@ button.shortcut-chip {
 }
 
 .onboarding-error {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
   margin: 0;
   color: var(--danger);
   font-size: 12px;
   font-weight: 600;
+}
+
+.onboarding-error > span {
+  flex: 1;
+}
+
+.onboarding-error > button {
+  display: grid;
+  width: 20px;
+  height: 20px;
+  flex: 0 0 20px;
+  place-items: center;
+  padding: 0;
+  border: 0;
+  border-radius: 4px;
+  color: inherit;
+  background: transparent;
+}
+
+.onboarding-error > button:hover {
+  background: color-mix(in srgb, var(--danger) 12%, transparent);
+}
+
+.onboarding-error > button svg {
+  width: 13px;
+  height: 13px;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -265,13 +265,15 @@ function App() {
           return;
         }
         try {
-          const { checkMicrophonePermission, checkScreenRecordingPermission } =
+          const { checkMicrophonePermission } =
             await import("tauri-plugin-macos-permissions-api");
-          const [microphone, capture] = await Promise.all([
-            checkMicrophonePermission(),
-            checkScreenRecordingPermission(),
-          ]);
-          setOnboarding(microphone && capture ? "done" : "returning");
+          // Only the microphone is required. Setup itself lets the user continue
+          // without screen recording, so demanding it here would wall off the app
+          // on every launch with no way to satisfy it. `startActiveMeeting` asks
+          // again when a meeting actually needs system audio.
+          setOnboarding(
+            (await checkMicrophonePermission()) ? "done" : "returning",
+          );
         } catch {
           // If the permissions cannot be read, do not block the app.
           setOnboarding("done");

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -268,9 +268,9 @@ function App() {
           const { checkMicrophonePermission } =
             await import("tauri-plugin-macos-permissions-api");
           // Only the microphone is required. Setup itself lets the user continue
-          // without screen recording, so demanding it here would wall off the app
-          // on every launch with no way to satisfy it. `startActiveMeeting` asks
-          // again when a meeting actually needs system audio.
+          // without screen recording, so demanding it here would block the app on
+          // every launch with no way to satisfy it. `startActiveMeeting` asks again
+          // when a meeting needs system audio.
           setOnboarding(
             (await checkMicrophonePermission()) ? "done" : "returning",
           );

--- a/src/Onboarding.test.tsx
+++ b/src/Onboarding.test.tsx
@@ -114,7 +114,7 @@ describe("Onboarding on macOS", () => {
     await waitFor(() => expect(rowButton("Microphone")).toBeEnabled());
     const advance = screen.getByRole("button", { name: "Continue" });
     expect(advance).toBeDisabled();
-    // A disabled control with no explanation strands the user: the screen has to
+    // A disabled control with no explanation strands the user. The screen has to
     // say which permission is still missing.
     expect(
       screen.getByText(/[Mm]icrophone .*(required|needed|before)/),
@@ -141,7 +141,7 @@ describe("Onboarding on macOS", () => {
 
     await exhaustPermissionPolling();
 
-    // The user is still in System Settings: the row must keep waiting and keep
+    // The user is still in System Settings. The row must keep waiting and keep
     // saying where to go, not revert to "Allow" as if nothing had happened.
     expect(row("Microphone")).toHaveTextContent("Waiting…");
     expect(guidanceText()).toMatch(/System Settings/);
@@ -155,7 +155,7 @@ describe("Onboarding on macOS", () => {
     fireEvent.click(rowButton("Microphone"));
     await exhaustPermissionPolling();
 
-    // The user is in System Settings; granting there must be picked up without
+    // The user is in System Settings. Setup must notice the grant without them
     // hunting for a "Check again" button they cannot see from that window.
     checkMicrophonePermission.mockResolvedValue(true);
     await act(async () => {
@@ -364,7 +364,7 @@ describe("Onboarding gate on relaunch", () => {
     render(<App />);
 
     // Onboarding itself treats system audio as optional, so an install that
-    // declined it must not meet a setup wall on every launch.
+    // declined it must not hit a setup screen on every launch.
     expect(
       await screen.findByRole("heading", { name: "Prepare for your meeting" }),
     ).toBeVisible();

--- a/src/Onboarding.test.tsx
+++ b/src/Onboarding.test.tsx
@@ -1,0 +1,398 @@
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import App from "./App";
+import Onboarding from "./Onboarding";
+import { resetBrowserDemoState } from "./lib/api";
+
+const checkMicrophonePermission = vi.fn<() => Promise<boolean>>();
+const checkScreenRecordingPermission = vi.fn<() => Promise<boolean>>();
+const requestMicrophonePermission = vi.fn<() => Promise<void>>();
+const requestScreenRecordingPermission = vi.fn<() => Promise<void>>();
+
+vi.mock("tauri-plugin-macos-permissions-api", () => ({
+  checkMicrophonePermission: () => checkMicrophonePermission(),
+  checkScreenRecordingPermission: () => checkScreenRecordingPermission(),
+  requestMicrophonePermission: () => requestMicrophonePermission(),
+  requestScreenRecordingPermission: () => requestScreenRecordingPermission(),
+}));
+
+const getAppStatus =
+  vi.fn<() => Promise<{ version: string; platform: string }>>();
+const getTranscriptionKeyStatus =
+  vi.fn<() => Promise<{ deepgram: boolean; assemblyAi: boolean }>>();
+const setTranscriptionApiKey =
+  vi.fn<
+    (
+      provider: string,
+      key: string,
+    ) => Promise<{ deepgram: boolean; assemblyAi: boolean }>
+  >();
+
+vi.mock("./lib/api", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./lib/api")>()),
+  getAppStatus: () => getAppStatus(),
+  getTranscriptionKeyStatus: () => getTranscriptionKeyStatus(),
+  setTranscriptionApiKey: (provider: string, key: string) =>
+    setTranscriptionApiKey(provider, key),
+}));
+
+/** Leaves the user in System Settings long enough for any bounded wait to lapse. */
+async function exhaustPermissionPolling() {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(20_000);
+  });
+}
+
+/** The visible guidance copy under the permission rows. */
+function guidanceText() {
+  return Array.from(document.querySelectorAll(".onboarding-note"))
+    .map((note) => note.textContent ?? "")
+    .join(" ");
+}
+
+/** The visible error copy, whatever element carries it. */
+function errorText() {
+  return document.querySelector(".onboarding-error")?.textContent ?? null;
+}
+
+async function findErrorText() {
+  await waitFor(() => expect(errorText()).not.toBeNull());
+  return errorText() ?? "";
+}
+
+function row(title: string) {
+  const heading = screen.getByText(title);
+  const element = heading.closest(".onboarding-row");
+  if (!element) throw new Error(`no permission row for ${title}`);
+  return element as HTMLElement;
+}
+
+function rowButton(title: string) {
+  const control = row(title).querySelector("button");
+  if (!control) throw new Error(`row ${title} has no action`);
+  return control;
+}
+
+function renderOnboarding(returningUser = false) {
+  const onComplete = vi.fn();
+  render(<Onboarding returningUser={returningUser} onComplete={onComplete} />);
+  return onComplete;
+}
+
+describe("Onboarding on macOS", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    getAppStatus.mockResolvedValue({ version: "0.1.0", platform: "macos" });
+    getTranscriptionKeyStatus.mockResolvedValue({
+      deepgram: false,
+      assemblyAi: false,
+    });
+    setTranscriptionApiKey.mockResolvedValue({
+      deepgram: true,
+      assemblyAi: false,
+    });
+    checkMicrophonePermission.mockResolvedValue(false);
+    checkScreenRecordingPermission.mockResolvedValue(false);
+    requestMicrophonePermission.mockResolvedValue(undefined);
+    requestScreenRecordingPermission.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("blocks Continue until the microphone is allowed and says why", async () => {
+    renderOnboarding();
+
+    await waitFor(() => expect(rowButton("Microphone")).toBeEnabled());
+    const advance = screen.getByRole("button", { name: "Continue" });
+    expect(advance).toBeDisabled();
+    // A disabled control with no explanation strands the user: the screen has to
+    // say which permission is still missing.
+    expect(
+      screen.getByText(/[Mm]icrophone .*(required|needed|before)/),
+    ).toBeVisible();
+  });
+
+  it("flips the row to Allowed as soon as macOS reports the grant", async () => {
+    renderOnboarding();
+    await waitFor(() => expect(rowButton("Microphone")).toBeEnabled());
+
+    checkMicrophonePermission.mockResolvedValue(true);
+    fireEvent.click(rowButton("Microphone"));
+
+    await waitFor(() => expect(row("Microphone")).toHaveTextContent("Allowed"));
+    expect(screen.getByRole("button", { name: "Continue" })).toBeEnabled();
+  });
+
+  it("guides the user to System Settings when the microphone stays denied", async () => {
+    renderOnboarding();
+    await waitFor(() => expect(rowButton("Microphone")).toBeEnabled());
+
+    fireEvent.click(rowButton("Microphone"));
+    expect(row("Microphone")).toHaveTextContent("Waiting…");
+
+    await exhaustPermissionPolling();
+
+    // The user is still in System Settings: the row must keep waiting and keep
+    // saying where to go, not revert to "Allow" as if nothing had happened.
+    expect(row("Microphone")).toHaveTextContent("Waiting…");
+    expect(guidanceText()).toMatch(/System Settings/);
+    expect(screen.getByRole("button", { name: "Continue" })).toBeDisabled();
+  });
+
+  it("recovers on its own when the grant lands after the poll window", async () => {
+    renderOnboarding();
+    await waitFor(() => expect(rowButton("Microphone")).toBeEnabled());
+
+    fireEvent.click(rowButton("Microphone"));
+    await exhaustPermissionPolling();
+
+    // The user is in System Settings; granting there must be picked up without
+    // hunting for a "Check again" button they cannot see from that window.
+    checkMicrophonePermission.mockResolvedValue(true);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3_000);
+    });
+
+    await waitFor(() => expect(row("Microphone")).toHaveTextContent("Allowed"));
+  });
+
+  it("re-reads permissions when the window regains focus", async () => {
+    renderOnboarding();
+    await waitFor(() => expect(rowButton("Microphone")).toBeEnabled());
+
+    checkMicrophonePermission.mockResolvedValue(true);
+    checkScreenRecordingPermission.mockResolvedValue(true);
+    await act(async () => {
+      window.dispatchEvent(new Event("focus"));
+      await vi.advanceTimersByTimeAsync(100);
+    });
+
+    await waitFor(() => expect(row("Microphone")).toHaveTextContent("Allowed"));
+    expect(row("Screen & system audio")).toHaveTextContent("Allowed");
+  });
+
+  it("reports a failed permission request instead of silently doing nothing", async () => {
+    requestMicrophonePermission.mockRejectedValue(new Error("plugin missing"));
+    renderOnboarding();
+    await waitFor(() => expect(rowButton("Microphone")).toBeEnabled());
+
+    fireEvent.click(rowButton("Microphone"));
+
+    expect(await findErrorText()).toMatch(
+      /could not request microphone access/i,
+    );
+    expect(rowButton("Microphone")).toHaveTextContent("Allow");
+  });
+
+  it("tells the user when the permission check itself fails", async () => {
+    getAppStatus.mockRejectedValue(new Error("ipc unavailable"));
+    renderOnboarding();
+
+    expect(await findErrorText()).toMatch(/check/i);
+  });
+
+  it("explains the screen recording restart requirement and keeps it optional", async () => {
+    checkMicrophonePermission.mockResolvedValue(true);
+    renderOnboarding();
+    await waitFor(() =>
+      expect(rowButton("Screen & system audio")).toBeEnabled(),
+    );
+
+    fireEvent.click(rowButton("Screen & system audio"));
+    await exhaustPermissionPolling();
+
+    expect(guidanceText()).toMatch(/reopen Savvy/);
+    expect(screen.getByRole("button", { name: "Continue" })).toBeEnabled();
+    expect(screen.getByText(/Savvy only hears you/)).toBeVisible();
+  });
+
+  it("lets the user dismiss an onboarding error", async () => {
+    requestMicrophonePermission.mockRejectedValue(new Error("plugin missing"));
+    renderOnboarding();
+    await waitFor(() => expect(rowButton("Microphone")).toBeEnabled());
+
+    fireEvent.click(rowButton("Microphone"));
+    await findErrorText();
+
+    fireEvent.click(screen.getByRole("button", { name: /Dismiss/i }));
+    expect(errorText()).toBeNull();
+  });
+
+  it("clears a stale error when the user moves to the next step", async () => {
+    requestMicrophonePermission.mockRejectedValue(new Error("plugin missing"));
+    renderOnboarding();
+    await waitFor(() => expect(rowButton("Microphone")).toBeEnabled());
+
+    fireEvent.click(rowButton("Microphone"));
+    await findErrorText();
+
+    checkMicrophonePermission.mockResolvedValue(true);
+    fireEvent.click(screen.getByRole("button", { name: "Check again" }));
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Continue" })).toBeEnabled(),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+
+    expect(await screen.findByText(/Deepgram API key/)).toBeVisible();
+    // The permission error belongs to the step the user just left.
+    expect(errorText()).toBeNull();
+  });
+
+  it("surfaces and then clears a key-storage failure", async () => {
+    checkMicrophonePermission.mockResolvedValue(true);
+    renderOnboarding();
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Continue" })).toBeEnabled(),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+
+    const field = await screen.findByPlaceholderText("Paste your API key");
+    setTranscriptionApiKey.mockRejectedValueOnce(new Error("Keychain locked"));
+    fireEvent.change(field, { target: { value: "test-api-key" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save key" }));
+
+    expect(await findErrorText()).toContain("Keychain locked");
+
+    setTranscriptionApiKey.mockResolvedValue({
+      deepgram: true,
+      assemblyAi: false,
+    });
+    fireEvent.change(field, { target: { value: "test-api-key" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save key" }));
+
+    await waitFor(() => expect(screen.getByText("Key saved")).toBeVisible());
+    expect(errorText()).toBeNull();
+  });
+
+  it("finishes without a key but says what will not work", async () => {
+    checkMicrophonePermission.mockResolvedValue(true);
+    const onComplete = renderOnboarding();
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Continue" })).toBeEnabled(),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+
+    expect(
+      await screen.findByText(/meetings cannot be transcribed/),
+    ).toBeVisible();
+    fireEvent.click(screen.getByRole("button", { name: "Skip for now" }));
+    expect(onComplete).toHaveBeenCalled();
+  });
+
+  it("announces onboarding errors to assistive technology", async () => {
+    requestMicrophonePermission.mockRejectedValue(new Error("plugin missing"));
+    renderOnboarding();
+    await waitFor(() => expect(rowButton("Microphone")).toBeEnabled());
+
+    fireEvent.click(rowButton("Microphone"));
+    await findErrorText();
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      /could not request microphone access/i,
+    );
+  });
+
+  it("does not carry a screen recording error into the key step", async () => {
+    checkMicrophonePermission.mockResolvedValue(true);
+    requestScreenRecordingPermission.mockRejectedValue(new Error("no plugin"));
+    renderOnboarding();
+    await waitFor(() =>
+      expect(rowButton("Screen & system audio")).toBeEnabled(),
+    );
+
+    fireEvent.click(rowButton("Screen & system audio"));
+    expect(await findErrorText()).toMatch(/screen recording access/i);
+
+    // Screen recording is optional, so Continue is the expected way forward.
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+    expect(await screen.findByText(/Deepgram API key/)).toBeVisible();
+    expect(errorText()).toBeNull();
+  });
+
+  it("sends a returning user straight back to work once repaired", async () => {
+    checkMicrophonePermission.mockResolvedValue(true);
+    checkScreenRecordingPermission.mockResolvedValue(true);
+    const onComplete = renderOnboarding(true);
+
+    expect(await screen.findByText(/needs its permissions back/)).toBeVisible();
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Continue" })).toBeEnabled(),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+    expect(onComplete).toHaveBeenCalled();
+    expect(getTranscriptionKeyStatus).not.toHaveBeenCalled();
+  });
+});
+
+describe("Onboarding gate on relaunch", () => {
+  beforeEach(() => {
+    resetBrowserDemoState();
+    getAppStatus.mockResolvedValue({ version: "0.1.0", platform: "macos" });
+    getTranscriptionKeyStatus.mockResolvedValue({
+      deepgram: true,
+      assemblyAi: false,
+    });
+    requestMicrophonePermission.mockResolvedValue(undefined);
+    requestScreenRecordingPermission.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => vi.clearAllMocks());
+
+  it("fronts setup when the microphone was revoked", async () => {
+    checkMicrophonePermission.mockResolvedValue(false);
+    checkScreenRecordingPermission.mockResolvedValue(true);
+    render(<App />);
+
+    expect(
+      await screen.findByRole("dialog", { name: "Set up Savvy" }),
+    ).toBeVisible();
+    expect(screen.getByText(/needs its permissions back/)).toBeVisible();
+  });
+
+  it("does not wall off the app over the optional screen recording permission", async () => {
+    checkMicrophonePermission.mockResolvedValue(true);
+    checkScreenRecordingPermission.mockResolvedValue(false);
+    render(<App />);
+
+    // Onboarding itself treats system audio as optional, so an install that
+    // declined it must not meet a setup wall on every launch.
+    expect(
+      await screen.findByRole("heading", { name: "Prepare for your meeting" }),
+    ).toBeVisible();
+    expect(
+      screen.queryByRole("dialog", { name: "Set up Savvy" }),
+    ).not.toBeInTheDocument();
+  }, 15_000);
+});
+
+describe("Onboarding off macOS", () => {
+  beforeEach(() => {
+    getAppStatus.mockResolvedValue({ version: "0.1.0", platform: "browser" });
+    getTranscriptionKeyStatus.mockResolvedValue({
+      deepgram: false,
+      assemblyAi: false,
+    });
+  });
+
+  afterEach(() => vi.clearAllMocks());
+
+  it("treats permissions as satisfied and never offers a dead control", async () => {
+    renderOnboarding();
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Continue" })).toBeEnabled(),
+    );
+    expect(row("Microphone")).toHaveTextContent("Allowed");
+    expect(row("Screen & system audio")).toHaveTextContent("Allowed");
+    expect(checkMicrophonePermission).not.toHaveBeenCalled();
+  });
+});

--- a/src/Onboarding.tsx
+++ b/src/Onboarding.tsx
@@ -1,11 +1,10 @@
 import { useCallback, useEffect, useState } from "react";
-import { Check, FileText, Mic, MonitorPlay } from "lucide-react";
+import { Check, FileText, Mic, MonitorPlay, X } from "lucide-react";
 import {
   getAppStatus,
   getTranscriptionKeyStatus,
   setTranscriptionApiKey,
 } from "./lib/api";
-import { requestPermissionDecision } from "./lib/permissions";
 import type { TranscriptionKeyStatus } from "./types";
 
 type Step = "permissions" | "transcription";
@@ -23,16 +22,22 @@ const PROVIDERS = [
 
 type ProviderId = (typeof PROVIDERS)[number]["id"];
 
+const PERMISSION_POLL_MS = 1_000;
+const MAX_CONSECUTIVE_CHECK_FAILURES = 3;
+const CHECK_FAILED = "Savvy could not check its permissions. Try again.";
+
 async function macosPermissions() {
   return import("tauri-plugin-macos-permissions-api");
 }
 
-type PermissionReading = { macos: boolean; mic: boolean; capture: boolean };
+type PermissionReading =
+  { ok: true; macos: boolean; mic: boolean; capture: boolean } | { ok: false };
 
 /**
  * Reads the current permission state. Returns rather than sets, so callers own the
  * state update — a reader that set state itself would be a synchronous setState
- * inside an effect.
+ * inside an effect. A failed read is reported as such: guessing "denied" would put
+ * the user in front of buttons that cannot work, with nothing explaining why.
  */
 async function readPermissions(): Promise<PermissionReading> {
   try {
@@ -40,7 +45,7 @@ async function readPermissions(): Promise<PermissionReading> {
     if (status.platform !== "macos") {
       // Nothing to grant off macOS; report satisfied rather than showing controls
       // that cannot do anything.
-      return { macos: false, mic: true, capture: true };
+      return { ok: true, macos: false, mic: true, capture: true };
     }
     const { checkMicrophonePermission, checkScreenRecordingPermission } =
       await macosPermissions();
@@ -48,12 +53,24 @@ async function readPermissions(): Promise<PermissionReading> {
       checkMicrophonePermission(),
       checkScreenRecordingPermission(),
     ]);
-    return { macos: true, mic, capture };
+    return { ok: true, macos: true, mic, capture };
   } catch {
-    // If the check itself fails, stop showing "Checking…" rather than trapping the
-    // user on a step whose state can never resolve.
-    return { macos: true, mic: false, capture: false };
+    return { ok: false };
   }
+}
+
+/**
+ * Folds a reading into a row. A grant always wins. While the user is away in System
+ * Settings the row stays `waiting` instead of snapping back to `needed` under them;
+ * only an explicit re-check resets that.
+ */
+function nextStatus(
+  current: PermissionStatus,
+  granted: boolean,
+  resetWaiting: boolean,
+): PermissionStatus {
+  if (granted) return "granted";
+  return current === "waiting" && !resetWaiting ? "waiting" : "needed";
 }
 
 /**
@@ -84,24 +101,72 @@ export default function Onboarding({
   const [error, setError] = useState<string | null>(null);
 
   const applyPermissions = useCallback(
-    ({ macos, mic, capture }: PermissionReading) => {
-      setIsMacos(macos);
-      setMicrophone(mic ? "granted" : "needed");
-      setScreen(capture ? "granted" : "needed");
+    (reading: PermissionReading, resetWaiting: boolean) => {
+      if (!reading.ok) return false;
+      setIsMacos(reading.macos);
+      setMicrophone((current) =>
+        nextStatus(current, reading.mic, resetWaiting),
+      );
+      setScreen((current) =>
+        nextStatus(current, reading.capture, resetWaiting),
+      );
+      return true;
     },
     [],
   );
+
+  /** The rows would otherwise sit on "Checking…" forever with nothing explaining it. */
+  const reportCheckFailure = useCallback(() => {
+    setIsMacos(true);
+    setMicrophone("needed");
+    setScreen("needed");
+    setError(CHECK_FAILED);
+  }, []);
 
   const refreshPermissions = useCallback(async () => {
     setError(null);
     setMicrophone("checking");
     setScreen("checking");
-    applyPermissions(await readPermissions());
-  }, [applyPermissions]);
+    if (!applyPermissions(await readPermissions(), true)) reportCheckFailure();
+  }, [applyPermissions, reportCheckFailure]);
 
   useEffect(() => {
-    void readPermissions().then(applyPermissions);
-  }, [applyPermissions]);
+    void readPermissions().then((reading) => {
+      if (!applyPermissions(reading, true)) reportCheckFailure();
+    });
+  }, [applyPermissions, reportCheckFailure]);
+
+  const settled = microphone === "granted" && screen === "granted";
+
+  // A grant is made in System Settings, outside this window, so the answer arrives
+  // whenever the user comes back — not within any fixed wait. Watch until it lands.
+  useEffect(() => {
+    if (step !== "permissions" || !isMacos || settled) return;
+    let failures = 0;
+    let stopped = false;
+    const poll = async () => {
+      if (stopped) return;
+      const reading = await readPermissions();
+      if (stopped) return;
+      if (applyPermissions(reading, false)) {
+        failures = 0;
+        return;
+      }
+      failures += 1;
+      if (failures < MAX_CONSECUTIVE_CHECK_FAILURES) return;
+      stopped = true;
+      window.clearInterval(timer);
+      setError(CHECK_FAILED);
+    };
+    const timer = window.setInterval(() => void poll(), PERMISSION_POLL_MS);
+    const onFocus = () => void poll();
+    window.addEventListener("focus", onFocus);
+    return () => {
+      stopped = true;
+      window.clearInterval(timer);
+      window.removeEventListener("focus", onFocus);
+    };
+  }, [applyPermissions, isMacos, settled, step]);
 
   useEffect(() => {
     if (returningUser) return;
@@ -114,17 +179,8 @@ export default function Onboarding({
     setError(null);
     setMicrophone("waiting");
     try {
-      const { checkMicrophonePermission, requestMicrophonePermission } =
-        await macosPermissions();
-      const granted = await requestPermissionDecision(
-        requestMicrophonePermission,
-        checkMicrophonePermission,
-      );
-      setMicrophone(granted ? "granted" : "needed");
-      if (granted) return;
-      setError(
-        "Allow Savvy microphone access in System Settings, then check again.",
-      );
+      const { requestMicrophonePermission } = await macosPermissions();
+      await requestMicrophonePermission();
     } catch {
       setMicrophone("needed");
       setError("Savvy could not request microphone access. Try again.");
@@ -135,19 +191,8 @@ export default function Onboarding({
     setError(null);
     setScreen("waiting");
     try {
-      const {
-        checkScreenRecordingPermission,
-        requestScreenRecordingPermission,
-      } = await macosPermissions();
-      const granted = await requestPermissionDecision(
-        requestScreenRecordingPermission,
-        checkScreenRecordingPermission,
-      );
-      setScreen(granted ? "granted" : "needed");
-      if (granted) return;
-      setError(
-        "Allow Savvy screen recording in System Settings, then check again. macOS may ask you to reopen Savvy.",
-      );
+      const { requestScreenRecordingPermission } = await macosPermissions();
+      await requestScreenRecordingPermission();
     } catch {
       setScreen("needed");
       setError("Savvy could not request screen recording access. Try again.");
@@ -195,7 +240,20 @@ export default function Onboarding({
           onGrant={grantScreenRecording}
           disabled={!isMacos}
         />
-        {error && <p className="onboarding-error">{error}</p>}
+        {microphone === "waiting" && (
+          <p className="onboarding-note">
+            Waiting for macOS. If no prompt appeared, allow Savvy under System
+            Settings › Privacy &amp; Security › Microphone.
+          </p>
+        )}
+        {screen === "waiting" && (
+          <p className="onboarding-note">
+            Waiting for macOS. Allow Savvy under System Settings › Privacy &amp;
+            Security › Screen &amp; System Audio Recording. macOS may ask you to
+            reopen Savvy.
+          </p>
+        )}
+        <ErrorNotice message={error} onDismiss={() => setError(null)} />
         <div className="onboarding-actions">
           <button
             className="button secondary"
@@ -206,13 +264,20 @@ export default function Onboarding({
           <button
             className="button"
             disabled={microphone !== "granted"}
-            onClick={() =>
-              returningUser ? onComplete() : setStep("transcription")
-            }
+            onClick={() => {
+              setError(null);
+              if (returningUser) onComplete();
+              else setStep("transcription");
+            }}
           >
             Continue
           </button>
         </div>
+        {microphone !== "granted" && microphone !== "checking" && (
+          <p className="onboarding-note">
+            Microphone access is required before you can continue.
+          </p>
+        )}
         {screen !== "granted" && microphone === "granted" && (
           <p className="onboarding-note">
             Without screen &amp; system audio, Savvy only hears you — not the
@@ -256,7 +321,7 @@ export default function Onboarding({
       <p className="onboarding-note">
         <FileText /> Stored in the macOS Keychain, never in settings or logs.
       </p>
-      {error && <p className="onboarding-error">{error}</p>}
+      <ErrorNotice message={error} onDismiss={() => setError(null)} />
       <div className="onboarding-actions">
         <button
           className="button secondary"
@@ -280,6 +345,30 @@ export default function Onboarding({
         </p>
       )}
     </OnboardingShell>
+  );
+}
+
+/** Setup errors are announced and dismissible, like the workspace error banner. */
+function ErrorNotice({
+  message,
+  onDismiss,
+}: {
+  message: string | null;
+  onDismiss: () => void;
+}) {
+  if (!message) return null;
+  return (
+    <p className="onboarding-error" role="alert">
+      <span>{message}</span>
+      <button
+        type="button"
+        aria-label="Dismiss alert"
+        title="Dismiss"
+        onClick={onDismiss}
+      >
+        <X />
+      </button>
+    </p>
   );
 }
 

--- a/src/Onboarding.tsx
+++ b/src/Onboarding.tsx
@@ -30,22 +30,21 @@ async function macosPermissions() {
   return import("tauri-plugin-macos-permissions-api");
 }
 
-type PermissionReading =
-  { ok: true; macos: boolean; mic: boolean; capture: boolean } | { ok: false };
+type PermissionReading = { macos: boolean; mic: boolean; capture: boolean };
 
 /**
  * Reads the current permission state. Returns rather than sets, so callers own the
  * state update — a reader that set state itself would be a synchronous setState
- * inside an effect. A failed read is reported as such: guessing "denied" would put
- * the user in front of buttons that cannot work, with nothing explaining why.
+ * inside an effect. A failed read returns null. Guessing "denied" would show the
+ * user buttons that cannot work, with nothing explaining why.
  */
-async function readPermissions(): Promise<PermissionReading> {
+async function readPermissions(): Promise<PermissionReading | null> {
   try {
     const status = await getAppStatus();
     if (status.platform !== "macos") {
       // Nothing to grant off macOS; report satisfied rather than showing controls
       // that cannot do anything.
-      return { ok: true, macos: false, mic: true, capture: true };
+      return { macos: false, mic: true, capture: true };
     }
     const { checkMicrophonePermission, checkScreenRecordingPermission } =
       await macosPermissions();
@@ -53,24 +52,10 @@ async function readPermissions(): Promise<PermissionReading> {
       checkMicrophonePermission(),
       checkScreenRecordingPermission(),
     ]);
-    return { ok: true, macos: true, mic, capture };
+    return { macos: true, mic, capture };
   } catch {
-    return { ok: false };
+    return null;
   }
-}
-
-/**
- * Folds a reading into a row. A grant always wins. While the user is away in System
- * Settings the row stays `waiting` instead of snapping back to `needed` under them;
- * only an explicit re-check resets that.
- */
-function nextStatus(
-  current: PermissionStatus,
-  granted: boolean,
-  resetWaiting: boolean,
-): PermissionStatus {
-  if (granted) return "granted";
-  return current === "waiting" && !resetWaiting ? "waiting" : "needed";
 }
 
 /**
@@ -100,20 +85,13 @@ export default function Onboarding({
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const applyPermissions = useCallback(
-    (reading: PermissionReading, resetWaiting: boolean) => {
-      if (!reading.ok) return false;
-      setIsMacos(reading.macos);
-      setMicrophone((current) =>
-        nextStatus(current, reading.mic, resetWaiting),
-      );
-      setScreen((current) =>
-        nextStatus(current, reading.capture, resetWaiting),
-      );
-      return true;
-    },
-    [],
-  );
+  const applyPermissions = useCallback((reading: PermissionReading | null) => {
+    if (!reading) return false;
+    setIsMacos(reading.macos);
+    setMicrophone(reading.mic ? "granted" : "needed");
+    setScreen(reading.capture ? "granted" : "needed");
+    return true;
+  }, []);
 
   /** The rows would otherwise sit on "Checking…" forever with nothing explaining it. */
   const reportCheckFailure = useCallback(() => {
@@ -127,19 +105,19 @@ export default function Onboarding({
     setError(null);
     setMicrophone("checking");
     setScreen("checking");
-    if (!applyPermissions(await readPermissions(), true)) reportCheckFailure();
+    if (!applyPermissions(await readPermissions())) reportCheckFailure();
   }, [applyPermissions, reportCheckFailure]);
 
   useEffect(() => {
     void readPermissions().then((reading) => {
-      if (!applyPermissions(reading, true)) reportCheckFailure();
+      if (!applyPermissions(reading)) reportCheckFailure();
     });
   }, [applyPermissions, reportCheckFailure]);
 
   const settled = microphone === "granted" && screen === "granted";
 
-  // A grant is made in System Settings, outside this window, so the answer arrives
-  // whenever the user comes back — not within any fixed wait. Watch until it lands.
+  // The user grants permissions in System Settings, outside this window, so the
+  // answer arrives whenever they come back, not within any fixed wait. Watch for it.
   useEffect(() => {
     if (step !== "permissions" || !isMacos || settled) return;
     let failures = 0;
@@ -148,15 +126,19 @@ export default function Onboarding({
       if (stopped) return;
       const reading = await readPermissions();
       if (stopped) return;
-      if (applyPermissions(reading, false)) {
-        failures = 0;
+      if (!reading) {
+        failures += 1;
+        if (failures < MAX_CONSECUTIVE_CHECK_FAILURES) return;
+        stopped = true;
+        window.clearInterval(timer);
+        setError(CHECK_FAILED);
         return;
       }
-      failures += 1;
-      if (failures < MAX_CONSECUTIVE_CHECK_FAILURES) return;
-      stopped = true;
-      window.clearInterval(timer);
-      setError(CHECK_FAILED);
+      failures = 0;
+      // Promote only. The user may be part way through granting in System
+      // Settings, and a row must not snap back to "Allow" under them.
+      if (reading.mic) setMicrophone("granted");
+      if (reading.capture) setScreen("granted");
     };
     const timer = window.setInterval(() => void poll(), PERMISSION_POLL_MS);
     const onFocus = () => void poll();
@@ -166,7 +148,7 @@ export default function Onboarding({
       window.clearInterval(timer);
       window.removeEventListener("focus", onFocus);
     };
-  }, [applyPermissions, isMacos, settled, step]);
+  }, [isMacos, settled, step]);
 
   useEffect(() => {
     if (returningUser) return;
@@ -275,7 +257,7 @@ export default function Onboarding({
         </div>
         {microphone !== "granted" && microphone !== "checking" && (
           <p className="onboarding-note">
-            Microphone access is required before you can continue.
+            Savvy needs microphone access before you can continue.
           </p>
         )}
         {screen !== "granted" && microphone === "granted" && (
@@ -348,7 +330,7 @@ export default function Onboarding({
   );
 }
 
-/** Setup errors are announced and dismissible, like the workspace error banner. */
+/** Shows a setup error the user can dismiss, matching the workspace error banner. */
 function ErrorNotice({
   message,
   onDismiss,


### PR DESCRIPTION
## What changed

Setup waited a fixed ten seconds for a permission grant. The user grants permissions
in System Settings, outside the app window, which takes longer than that. When the
wait ran out, the row went back to "Allow" and nothing checked again. Someone who had
just allowed the microphone got a screen telling them to allow the microphone.

Setup now watches until the grant lands. It polls once a second and on window focus
while the permission step is open, and it holds the row in "Waiting" instead of
resetting it while the user is away. Three consecutive failed checks now produce a
"could not check permissions" message. Before, a single failed check read as a denial.

The rest of the screen follows from that.

- The screen names the microphone as the thing blocking Continue, instead of leaving
  the button disabled with no explanation.
- While a row waits, the screen names the System Settings pane that grants it, and
  says macOS may ask the user to reopen Savvy after granting screen recording.
- Errors carry `role="alert"` and a dismiss button, matching the workspace error
  banner. Moving between steps clears them, so a permission error no longer follows
  the user onto the transcription key step.

On relaunch, only a missing microphone fronts setup. Screen recording is optional in
setup itself, since Continue works without it. Requiring it on launch put returning
users in front of a repair screen they could not satisfy, every time they opened the
app. Starting a meeting still asks for it.

## Tests

`src/Onboarding.test.tsx` drives the permission step against a mocked
`tauri-plugin-macos-permissions-api`. It covers a grant, a denial, a grant that lands
after the old ten-second window, the re-check on focus, a failing request, a failing
check, error dismissal, error clearing across steps, key storage failure and recovery,
finishing without a key, the returning-user path, and the non-macOS path. Two more
tests cover which permission state fronts setup on relaunch.

## Verification

`pnpm typecheck`, `pnpm lint`, `pnpm test`, `pnpm format:check` and `pnpm build` pass.
I did not run `pnpm verify` in full. The machine I wrote this on has no Rust
toolchain, so `cargo clippy` and `cargo test` did not run. No Rust changed. I also did
not test the System Settings round trip on a real Mac.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
