### PR TITLE
fix: stop overlay window swallowing clicks around the card

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3855,7 +3855,7 @@ dependencies = [
 
 [[package]]
 name = "savvy"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "chrono",
  "flume",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "savvy",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "savvy"
-version = "0.1.0"
+version = "0.1.1"
 description = "Savvy, a meeting assistant grounded in your own sources"
 authors = ["Alamas Labs, Inc."]
 repository = "https://github.com/jamalavedra/savvy"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -841,6 +841,26 @@ fn set_shortcut_recording(
     }
 }
 
+#[tauri::command]
+fn set_overlay_expanded(
+    expanded: bool,
+    app: AppHandle,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
+    #[cfg(target_os = "macos")]
+    {
+        let settings = state
+            .settings
+            .lock()
+            .map_err(|_| "settings lock poisoned")?
+            .clone();
+        overlay::set_expanded(&app, &settings, expanded);
+    }
+    #[cfg(not(target_os = "macos"))]
+    let _ = (expanded, app, state);
+    Ok(())
+}
+
 fn validate_settings(settings: &AppSettings) -> Result<(), String> {
     if !(0.0..=1.0).contains(&settings.audio_feedback_volume) {
         return Err("audio feedback volume must be between 0 and 1".into());
@@ -5033,6 +5053,7 @@ pub fn run() {
             get_output_devices,
             check_for_updates,
             set_shortcut_recording,
+            set_overlay_expanded,
             get_dashboard,
             get_preparation_snapshot,
             get_meeting_history,

--- a/src-tauri/src/overlay.rs
+++ b/src-tauri/src/overlay.rs
@@ -12,8 +12,17 @@ tauri_panel! {
     })
 }
 
+// The window is kept barely larger than the card it hosts and resized per UI
+// state (see `set_expanded`), because macOS still routes clicks to the window's
+// transparent regions — a fixed max-size window would swallow clicks meant for
+// the app underneath. Keep these in sync with the card geometry in App.css:
+// expanded fits the open card (392w, max-height 320) plus the .ov-stage
+// padding (14px sides, 10px anchored edge); collapsed fits the 216px-wide
+// status pill (~82px tall) plus the same padding.
 const WIDTH: f64 = 420.0;
 const HEIGHT: f64 = 340.0;
+const COLLAPSED_WIDTH: f64 = 244.0;
+const COLLAPSED_HEIGHT: f64 = 96.0;
 const TOP_OFFSET: f64 = 32.0;
 const BOTTOM_OFFSET: f64 = 15.0;
 
@@ -40,22 +49,23 @@ fn logical_position(
     work_area_size: PhysicalSize<u32>,
     scale: f64,
     overlay_position: &str,
+    (width, height): (f64, f64),
 ) -> (f64, f64) {
     let monitor_x = f64::from(monitor_position.x) / scale;
     let monitor_y = f64::from(monitor_position.y) / scale;
     let monitor_width = f64::from(monitor_size.width) / scale;
-    let x = monitor_x + (monitor_width - WIDTH) / 2.0;
+    let x = monitor_x + (monitor_width - width) / 2.0;
     let y = if overlay_position == "top" {
         monitor_y + TOP_OFFSET
     } else {
         (f64::from(work_area_position.y) + f64::from(work_area_size.height)) / scale
-            - HEIGHT
+            - height
             - BOTTOM_OFFSET
     };
     (x, y)
 }
 
-fn position(app: &AppHandle, settings: &AppSettings) -> Option<(f64, f64)> {
+fn position(app: &AppHandle, settings: &AppSettings, size: (f64, f64)) -> Option<(f64, f64)> {
     let monitor = monitor_with_cursor(app)?;
     let work_area = monitor.work_area();
     Some(logical_position(
@@ -65,11 +75,41 @@ fn position(app: &AppHandle, settings: &AppSettings) -> Option<(f64, f64)> {
         work_area.size,
         monitor.scale_factor(),
         &settings.overlay_position,
+        size,
     ))
 }
 
+fn current_logical_size(window: &tauri::WebviewWindow) -> Option<(f64, f64)> {
+    let size = window.inner_size().ok()?;
+    let scale = window.scale_factor().ok()?;
+    Some((
+        f64::from(size.width) / scale,
+        f64::from(size.height) / scale,
+    ))
+}
+
+/// New top-left origin for a resize that keeps the card's anchored edge fixed:
+/// horizontally centered, pinned to the top edge for the "top" overlay
+/// position and to the bottom edge otherwise. Works from the window's current
+/// frame rather than recomputing from the monitor, so a user-dragged overlay
+/// stays where it was dropped.
+fn anchored_origin(
+    origin: (f64, f64),
+    old_size: (f64, f64),
+    new_size: (f64, f64),
+    anchor_top: bool,
+) -> (f64, f64) {
+    let x = origin.0 + (old_size.0 - new_size.0) / 2.0;
+    let y = if anchor_top {
+        origin.1
+    } else {
+        origin.1 + old_size.1 - new_size.1
+    };
+    (x, y)
+}
+
 pub fn create(app: &AppHandle, settings: &AppSettings) {
-    let Some((x, y)) = position(app, settings) else {
+    let Some((x, y)) = position(app, settings, (COLLAPSED_WIDTH, COLLAPSED_HEIGHT)) else {
         log::error!("overlay creation failed: no monitor available");
         return;
     };
@@ -79,8 +119,8 @@ pub fn create(app: &AppHandle, settings: &AppSettings) {
         .position(Position::Logical(tauri::LogicalPosition { x, y }))
         .level(PanelLevel::Status)
         .size(Size::Logical(tauri::LogicalSize {
-            width: WIDTH,
-            height: HEIGHT,
+            width: COLLAPSED_WIDTH,
+            height: COLLAPSED_HEIGHT,
         }))
         .has_shadow(false)
         .transparent(true)
@@ -116,17 +156,13 @@ pub fn show(app: &AppHandle, settings: &AppSettings) {
             log::error!("meeting overlay show failed: window is missing");
             return;
         };
-        let Some((x, y)) = position(&handle, &settings) else {
+        // The webview drives the window size via `set_expanded`; showing only
+        // re-centers the current footprint on the monitor with the cursor.
+        let size = current_logical_size(&window).unwrap_or((COLLAPSED_WIDTH, COLLAPSED_HEIGHT));
+        let Some((x, y)) = position(&handle, &settings, size) else {
             log::error!("meeting overlay show failed: no monitor available");
             return;
         };
-        if let Err(error) = window.set_size(Size::Logical(tauri::LogicalSize {
-            width: WIDTH,
-            height: HEIGHT,
-        })) {
-            log::error!("meeting overlay resize failed: {error}");
-            return;
-        }
         if let Err(error) = window.set_position(Position::Logical(tauri::LogicalPosition { x, y }))
         {
             log::error!("meeting overlay position failed: {error}");
@@ -136,6 +172,62 @@ pub fn show(app: &AppHandle, settings: &AppSettings) {
             Ok(()) => log::info!("meeting overlay shown at x={x:.0} y={y:.0}"),
             Err(error) => log::error!("meeting overlay show failed: {error}"),
         }
+    }) {
+        log::error!("meeting overlay main-thread dispatch failed: {error}");
+    }
+}
+
+/// Resizes the overlay window to fit the card's expanded or collapsed
+/// footprint, keeping the card's anchored screen edge fixed. Invoked by the
+/// overlay webview whenever the card grows or finishes shrinking.
+pub fn set_expanded(app: &AppHandle, settings: &AppSettings, expanded: bool) {
+    let handle = app.clone();
+    let anchor_top = settings.overlay_position == "top";
+    if let Err(error) = app.run_on_main_thread(move || {
+        let Some(window) = handle.get_webview_window("meeting-overlay") else {
+            log::error!("meeting overlay resize failed: window is missing");
+            return;
+        };
+        let size = if expanded {
+            (WIDTH, HEIGHT)
+        } else {
+            (COLLAPSED_WIDTH, COLLAPSED_HEIGHT)
+        };
+        let (Ok(scale), Ok(origin), Some(old_size)) = (
+            window.scale_factor(),
+            window.outer_position(),
+            current_logical_size(&window),
+        ) else {
+            log::error!("meeting overlay resize failed: window frame unavailable");
+            return;
+        };
+        if (old_size.0 - size.0).abs() < 1.0 && (old_size.1 - size.1).abs() < 1.0 {
+            return;
+        }
+        let (x, y) = anchored_origin(
+            (f64::from(origin.x) / scale, f64::from(origin.y) / scale),
+            old_size,
+            size,
+            anchor_top,
+        );
+        if let Err(error) = window.set_size(Size::Logical(tauri::LogicalSize {
+            width: size.0,
+            height: size.1,
+        })) {
+            log::error!("meeting overlay resize failed: {error}");
+            return;
+        }
+        if let Err(error) = window.set_position(Position::Logical(tauri::LogicalPosition { x, y }))
+        {
+            log::error!("meeting overlay position failed: {error}");
+            return;
+        }
+        log::info!(
+            "meeting overlay {} to {:.0}x{:.0}",
+            if expanded { "expanded" } else { "collapsed" },
+            size.0,
+            size.1
+        );
     }) {
         log::error!("meeting overlay main-thread dispatch failed: {error}");
     }
@@ -164,8 +256,23 @@ mod tests {
                 PhysicalSize::new(3440, 1390),
                 2.0,
                 "bottom",
+                (WIDTH, HEIGHT),
             ),
             (650.0, 340.0)
+        );
+    }
+
+    #[test]
+    fn resize_pins_the_anchored_edge_and_keeps_the_center() {
+        // Bottom overlay: the bottom edge (y + height) must not move.
+        assert_eq!(
+            anchored_origin((650.0, 340.0), (420.0, 340.0), (244.0, 96.0), false),
+            (738.0, 584.0)
+        );
+        // Top overlay: the top edge must not move.
+        assert_eq!(
+            anchored_origin((650.0, 32.0), (244.0, 96.0), (420.0, 340.0), true),
+            (562.0, 32.0)
         );
     }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Savvy",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "identifier": "com.alamaslabs.savvy",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -66,6 +66,7 @@ import {
   removeBrief,
   removeClientContext,
   resumeMeeting,
+  setOverlayExpanded,
   setTranscriptionApiKey,
   setShortcutRecording,
   startMeeting,
@@ -1894,6 +1895,22 @@ export function MeetingOverlay({
     visibleRecommendation || error || confirmingStop,
   );
   const open = style === "live" && (hasText || showExtension);
+  // The card grows vertically whenever `.has-text` or `.ai-open` applies
+  // (regardless of overlay style), so the native window must grow with it.
+  const expanded = hasText || showExtension;
+
+  // Grow the window before the card's open animation needs the room; shrink
+  // only after the 440-460ms close animation has finished, so the card is
+  // never clipped. The window otherwise stays wrapped tightly around the card
+  // because its transparent regions still swallow clicks on macOS.
+  useEffect(() => {
+    if (expanded) {
+      void setOverlayExpanded(true);
+      return;
+    }
+    const timer = window.setTimeout(() => void setOverlayExpanded(false), 520);
+    return () => window.clearTimeout(timer);
+  }, [expanded]);
 
   useEffect(() => {
     if (!session) return;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -326,6 +326,11 @@ export async function checkForUpdates(): Promise<boolean> {
   return invoke<boolean>("check_for_updates");
 }
 
+export async function setOverlayExpanded(expanded: boolean): Promise<void> {
+  if (!window.__TAURI_INTERNALS__) return;
+  return invoke("set_overlay_expanded", { expanded });
+}
+
 export async function setShortcutRecording(active: boolean): Promise<void> {
   if (!window.__TAURI_INTERNALS__) return;
   return invoke("set_shortcut_recording", { active });


### PR DESCRIPTION
## Problem

While the meeting overlay is visible, clicks in the screen region directly above the card never reach the app underneath. The overlay panel is a fixed 420x340 transparent window with the card anchored at its bottom edge, leaving ~250px of invisible window above the card — and macOS routes clicks to a window's transparent regions, so they die there. Tauri has no per-pixel click-through (tauri-apps/tauri#2090, #13070).

## Fix

Size the native window to the card's footprint and resize it per UI state, the same approach Handy uses for its recording overlay:

- The panel is created and shown at a collapsed 244x96 footprint that wraps the status pill; it grows to 420x340 only while the card shows transcript text or the extension (recommendation, stop confirmation, error).
- A new `set_overlay_expanded` command performs the resize. The overlay webview invokes it when the card's height state changes: growing immediately so the open animation has room, shrinking 520ms after close so the 440-460ms collapse animation is never clipped.
- The resize pins the card's anchored screen edge (bottom, or top for the "top" overlay position) and horizontal center from the window's current frame, so an overlay the user dragged elsewhere stays where it was dropped. `show()` no longer forces a size; it re-centers the current footprint on the monitor with the cursor.

## Tests

- `cargo test -p savvy`: existing `logical_position` test updated for the size parameter; new test pins the anchored-edge math for both overlay positions.
- `pnpm typecheck`, `pnpm lint`, `pnpm test` (41 passed), `cargo clippy -p savvy --all-targets -- -D warnings`, `cargo fmt --check`, `pnpm format:check` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)