### PR TITLE
fix: preserve setup across updates and prepare 0.1.2

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,10 +6,9 @@ Build prerequisites are in the [README](README.md#building-from-source). Run `pn
 opening a pull request — it runs formatting, typecheck, lint, the frontend and Rust test suites,
 a production build, and Clippy with warnings denied. CI runs the same command.
 
-The test suite runs on macOS only — `savvy-audio` depends on ScreenCaptureKit, so the workspace
-does not compile anywhere else. CI additionally `cargo check`s Linux and Windows so the
-non-macOS stubs do not rot. Audio capture, Keychain access, the overlay window, and the tray are
-macOS-only, so changes touching those need a Mac to verify.
+CI runs the full test suite on macOS and `cargo check` on Linux and Windows. The workspace
+compiles on all three platforms. Audio capture, Keychain access, the overlay window, and the
+tray are macOS-only, so changes touching those need a Mac to verify.
 
 ## Implementation rules
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3855,7 +3855,7 @@ dependencies = [
 
 [[package]]
 name = "savvy"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "chrono",
  "flume",

--- a/README.md
+++ b/README.md
@@ -55,7 +55,13 @@ On first launch the app asks for microphone and screen-recording permission, the
 
 To use the recommendation features you also need `codex` or `claude` on your `PATH` and signed in; Savvy reports provider status in Settings.
 
-Tests run on macOS only — `savvy-audio` depends on ScreenCaptureKit, so the workspace does not compile anywhere else. CI additionally runs `cargo check` on Linux and Windows so the non-macOS `cfg` stubs do not rot. Audio capture, Keychain access, and the overlay are macOS-only and guarded by `cfg(target_os = "macos")`.
+Completed setup survives application updates. Microphone access is checked when you start a meeting. If macOS already lists Savvy as allowed but setup disagrees, use **Check again** to verify system-audio access through ScreenCaptureKit. If it still waits after you press Allow, choose **Reopen Savvy**. Savvy does not require Accessibility permission. Development-signed and release-signed builds can have different macOS permission identities.
+
+If your preferred microphone is disconnected before a meeting starts, Savvy uses the system default for that recording and remembers your preference for when it reconnects. A disconnect during a meeting shows a capture error; stop the meeting, reconnect the device, and start again. Savvy does not switch formats inside an existing recording.
+
+Using a Bluetooth headset's microphone can reduce the headset's playback quality while it records. Select the Mac's built-in microphone or a USB microphone if you want to keep Bluetooth playback quality.
+
+CI runs the full test suite on macOS and `cargo check` on Linux and Windows. The workspace compiles on all three platforms, but audio capture, Keychain access, the overlay, and the tray are guarded by `cfg(target_os = "macos")` and need a Mac to verify.
 
 ## Repository layout
 

--- a/crates/audio/src/lib.rs
+++ b/crates/audio/src/lib.rs
@@ -92,6 +92,14 @@ impl Default for SystemAudioCapture {
 
 #[cfg(target_os = "macos")]
 impl SystemAudioCapture {
+    /// Explicit user-requested permission probe. ScreenCaptureKit may show the
+    /// system prompt, so do not run this during passive startup polling.
+    pub fn check_permission() -> Result<(), AudioError> {
+        SCShareableContent::get()
+            .map(|_| ())
+            .map_err(|error| AudioError::Capture(error.to_string()))
+    }
+
     pub fn new() -> Self {
         let (sender, receiver) = flume::bounded(64);
         Self {
@@ -137,8 +145,13 @@ impl MicrophoneCapture {
         self.last_error.lock().ok().and_then(|value| value.clone())
     }
 
-    pub fn level(&self) -> f32 {
-        f32::from_bits(self.level.load(Ordering::Relaxed))
+    pub fn level(&self) -> Result<f32, AudioError> {
+        if let Some(error) = self.last_error() {
+            return Err(AudioError::Capture(format!(
+                "Microphone capture stopped: {error}. Stop this meeting, reconnect your microphone, then start a new meeting."
+            )));
+        }
+        Ok(f32::from_bits(self.level.load(Ordering::Relaxed)))
     }
 
     pub fn configure(
@@ -449,30 +462,55 @@ fn find_device(
     selected: Option<&str>,
     input: bool,
 ) -> Result<cpal::Device, AudioError> {
-    if let Some(selected) = selected {
+    let devices = if selected.is_some() {
         let devices = if input {
             host.input_devices()
         } else {
             host.output_devices()
         }
         .map_err(|error| AudioError::DeviceUnavailable(error.to_string()))?;
-        return devices
+        devices
             .filter_map(|device| {
                 device
                     .description()
                     .ok()
                     .map(|description| (description.name().to_owned(), device))
             })
-            .find(|(name, _)| name == selected)
-            .map(|(_, device)| device)
-            .ok_or_else(|| AudioError::DeviceUnavailable(selected.into()));
-    }
-    (if input {
-        host.default_input_device()
+            .collect()
     } else {
-        host.default_output_device()
+        Vec::new()
+    };
+    resolve_device(
+        selected,
+        devices,
+        || {
+            if input {
+                host.default_input_device()
+            } else {
+                host.default_output_device()
+            }
+        },
+        input,
+    )
+}
+
+fn resolve_device<T>(
+    selected: Option<&str>,
+    devices: Vec<(String, T)>,
+    default: impl FnOnce() -> Option<T>,
+    input: bool,
+) -> Result<T, AudioError> {
+    if let Some(selected) = selected {
+        if let Some((_, device)) = devices.into_iter().find(|(name, _)| name == selected) {
+            return Ok(device);
+        }
+        if !input {
+            return Err(AudioError::DeviceUnavailable(selected.into()));
+        }
+    }
+    default().ok_or_else(|| {
+        AudioError::DeviceUnavailable("no system default device is configured".into())
     })
-    .ok_or_else(|| AudioError::DeviceUnavailable("no system default device is configured".into()))
 }
 
 fn send_input_frame(
@@ -526,6 +564,7 @@ fn select_channel(
 impl AudioCapture for MicrophoneCapture {
     fn start(&mut self) -> Result<(), AudioError> {
         if self.stream.is_some() {
+            self.level()?;
             return Ok(());
         }
         if let Ok(mut error) = self.last_error.lock() {
@@ -564,6 +603,7 @@ impl AudioCapture for MicrophoneCapture {
     }
 
     fn resume(&mut self) -> Result<(), AudioError> {
+        self.level()?;
         self.stream
             .as_ref()
             .ok_or_else(|| AudioError::Capture("microphone is not running".into()))?
@@ -775,6 +815,33 @@ pub fn downmix_to_mono(frame: &AudioFrame) -> Vec<f32> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn missing_microphone_falls_back_but_output_selection_stays_explicit() {
+        assert_eq!(
+            resolve_device(Some("USB"), vec![("USB".into(), 1)], || Some(2), true).unwrap(),
+            1
+        );
+        assert_eq!(
+            resolve_device(Some("USB"), vec![], || Some(2), true).unwrap(),
+            2
+        );
+        assert!(resolve_device::<i32>(Some("USB"), vec![], || None, true).is_err());
+        assert!(resolve_device(Some("USB"), vec![], || Some(2), false).is_err());
+        assert_eq!(
+            resolve_device(None, vec![("USB".into(), 1)], || Some(2), false).unwrap(),
+            2
+        );
+        let mut capture = MicrophoneCapture::new();
+        capture.level.store(0.5f32.to_bits(), Ordering::Relaxed);
+        *capture.last_error.lock().unwrap() = Some("device disconnected".into());
+        assert!(capture
+            .level()
+            .unwrap_err()
+            .to_string()
+            .contains("Stop this meeting"));
+        assert!(capture.resume().is_err());
+    }
 
     #[test]
     fn stereo_frames_are_downmixed_without_crossing_frames() {

--- a/docs/update-permissions-investigation.md
+++ b/docs/update-permissions-investigation.md
@@ -1,0 +1,67 @@
+# Update and permission investigation
+
+Investigated September 5, 2026 against Savvy `02bad43`, its published v0.1.0 and v0.1.1 updater bundles, Tauri 2.11.5, updater 2.10.1, and macOS permissions plugin 2.3.0.
+
+## Findings
+
+The repeated setup screen has a confirmed application-level cause. `App.tsx` read `onboardingCompleted`, then checked microphone permission even when setup was complete. One `false` result changed the UI to the returning-user setup screen. That path did not distinguish a revoked grant from a temporarily unrecognized grant after replacement of the app bundle. It also prevented access to the rest of the app while the user tried to recover.
+
+This was a permission-repair screen, not proof that stored onboarding had been erased. Inspection of the current installed settings found `onboardingCompleted: true`. Only that flag and field types were inspected for this investigation; settings values, credentials, source documents, and meeting content are not included here. The flag's current value cannot establish its value during the reported incident.
+
+A separate confirmed settings-loader defect could also repeat setup. When any one JSON field had the wrong type, `settings::load` returned all defaults, including `onboardingCompleted: false`. Correctly typed newly added or missing fields were already handled through Serde defaults. Malformed fields were the gap. This defect is fixed, but there is no incident evidence that it caused this particular update failure.
+
+## Signing identity was checked against shipped artifacts
+
+Both published updater archives were downloaded into a temporary inspection directory and extracted without launching either application. Both passed `codesign --verify --deep --strict`.
+
+| Property               | v0.1.0                   | v0.1.1                   |
+| ---------------------- | ------------------------ | ------------------------ |
+| Bundle identifier      | `com.alamaslabs.savvy`   | `com.alamaslabs.savvy`   |
+| Signing channel        | Developer ID Application | Developer ID Application |
+| Team identifier        | Same team                | Same team                |
+| Designated requirement | Same requirement         | Same requirement         |
+| Published              | August 20, 2026          | August 31, 2026          |
+
+Apple explains that macOS uses designated requirements to recognize an updated app when checking microphone authorization. The matching requirements rule out a changed release identity as the explanation for a v0.1.0 to v0.1.1 release-to-release update. They do not prove the state of the user's TCC database. [Apple TN3127](https://developer.apple.com/documentation/technotes/tn3127-inside-code-signing-requirements)
+
+The local build/install script signs with an Apple Development identity by default. Moving between a local build and a published release can therefore require new grants even when the bundle identifier stays the same. Apple's documentation explicitly distinguishes these signing channels. Do not reset permissions or change signing requirements to hide this distinction.
+
+## Why relaunch can change the answer
+
+The pinned Tauri implementation was inspected directly in the Cargo registry. `AppHandle::restart` eventually calls `tauri::process::restart`. Its macOS path reads `CFBundleExecutable` from the replacement Info.plist and directly spawns `Contents/MacOS/<executable>` before exiting the old process. It does not launch the replacement through Launch Services or wait for the old instance to exit first. [Tauri 2.11.5 process implementation](https://github.com/tauri-apps/tauri/blob/tauri-v2.11.5/crates/tauri/src/process.rs)
+
+The updater replaces the app bundle, but leaves application support settings in place. Combining a direct child-process relaunch with a one-shot startup permission gate is a plausible explanation for the observed "allowed in System Settings, recognized only after quitting and reopening" sequence. This remains an inference: no TCC trace from the incident was available, and the historical update was not reproduced against the user's installed application.
+
+The changed relaunch path waits for the previous process to exit, then runs `/usr/bin/open -n <bundle>` through Launch Services. The app path is passed as an argument, never interpolated into shell code. This also avoids a replacement instance seeing the old instance's still-active meeting record. Apple's explanation of launch contexts distinguishes Launch Services application launches from ordinary process spawning. [Apple WWDC23 launch constraints](https://developer.apple.com/videos/play/wwdc2023/10266/)
+
+## The reported permission name
+
+Savvy checks microphone and screen/system-audio access. Its frontend has no Accessibility check or request, and its Tauri capability file does not authorize those Accessibility plugin commands. Handy does require Accessibility for its dictation shortcuts and input automation. Handy has an open report about stale Accessibility entries after upgrades, but that is not evidence that Savvy exercises the same API. [Handy issue #1618](https://github.com/cjpais/Handy/issues/1618)
+
+Savvy's permission plugin checks microphone status through `AVCaptureDevice.authorizationStatusForMediaType` and screen capture through `CGPreflightScreenCaptureAccess`. Its actual system-audio capture uses ScreenCaptureKit. The fix adds an explicit ScreenCaptureKit permission probe when the user presses Check again or requests screen access and preflight still reports false. Successful retrieval of shareable content marks the permission allowed; it does not claim that a recording has been tested. Passive startup and timer checks do not run that potentially prompting probe. [ScreenCaptureKit shareable content](https://developer.apple.com/documentation/screencapturekit/scshareablecontent)
+
+## Implemented behavior
+
+- Completed onboarding remains completed. The microphone check at Start listening still enforces access before recording.
+- Invalid stored field types no longer discard valid preferences or a valid completion flag. Existing migrations still run, and loading does not rewrite the original file.
+- An explicit screen-access recheck uses ScreenCaptureKit when CoreGraphics preflight says no.
+- Setup offers Reopen Savvy while a requested permission is still unrecognized.
+- macOS updates and that recovery action use the same Launch Services relaunch helper after the old process exits.
+- Update/reopen requests refuse to interrupt a meeting. Capture and settings transitions are serialized, and new operations are blocked while an accepted update is running.
+- Download/install or relaunch-scheduling failures are shown to the user and unblock operations.
+- Startup update checks begin after application state and windows have been initialized.
+- Quit waits for capture and settings work on a worker thread so the macOS event loop can finish pending native operations.
+
+No grant is fabricated, no TCC database is edited, and no permission is reset automatically.
+
+## Verification and remaining limits
+
+`pnpm verify` passed with 44 frontend tests and 76 Rust tests; two pre-existing external-provider tests remain ignored. Formatting, TypeScript, ESLint, the production build, and Clippy also passed.
+
+Regression tests exercise completed setup with a false microphone reading, valid preferences alongside malformed fields, stale screen preflight with a successful ScreenCaptureKit probe, reopen error reporting, and the relaunch helper waiting for its parent to exit while preserving literal arguments. Existing tests still cover genuinely missing microphone access in first-run setup.
+
+The relaunch helper test runs a harmless substitute command; it does not launch an app, grant permission, or access the microphone. Native compilation and tests cannot prove a particular macOS TCC transition.
+
+For release verification, use a signed installed build with pre-existing microphone and screen grants, update it, and confirm that the workspace opens, both audio sources can record, and the completion flag stays true. Also check a denied microphone, screen access granted while the app runs, failure to download an update, and an update attempt during a meeting.
+
+The first upgrade into this fix is restarted by the old installed version. That version still uses Tauri's old restart path. The new onboarding behavior applies immediately, but a stale process permission state may require one Reopen Savvy action or a normal quit/reopen. Later updates use the new launch path. A complete signed update-cycle test remains manual; this work does not claim that the historical TCC failure was reproduced.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "savvy",
   "private": true,
-  "version": "0.1.1",
+  "version": "0.1.2",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/plan/upgrade-handy-improvements-1.md
+++ b/plan/upgrade-handy-improvements-1.md
@@ -1,0 +1,180 @@
+---
+goal: Apply shipped Handy reliability improvements that fit Savvy
+version: 1
+date_created: 2026-09-05
+last_updated: 2026-09-05
+owner: Savvy maintainers
+status: Completed
+tags: [upgrade, reliability, upstream-review]
+---
+
+# Introduction
+
+![Status: Completed](https://img.shields.io/badge/status-Completed-brightgreen)
+
+Review baseline: Savvy `02bad43`; Handy releases v0.9.0 through v0.9.6, July 1 through August 24, 2026. GitHub reports v0.9.6 as the latest stable release. Savvy has its own initial public commit and crate structure, with no Handy remote or shared fork point available locally. Adapt the behavior to Savvy rather than cherry-picking Handy's files.
+
+Handy's `main` was 12 commits ahead of v0.9.6 at review time, ending at `bc7facea3a777869182203cfcf5c90f7a98efd99`. Those commits, including tail-audio handling, experimental VAD, log redaction, and automatic push-to-talk, are unreleased and excluded from the shipped-change scope.
+
+## 1. Requirements and constraints
+
+- REQ-001: Keep correctly typed stored settings when another field has a bad type. Preserve legacy onboarding and AssemblyAI migrations.
+- REQ-002: Synchronize saved settings across webviews and apply the native theme at startup and after changes.
+- REQ-003: Unmount the idle overlay. Bound microphone polling to one pending request and stop on pause, hidden documents, or unmount.
+- REQ-004: Fall back to the default input only when a selected microphone is confirmed absent. Preserve output-device selection semantics and do not mask enumeration failures.
+- REQ-005: Run meeting capture operations on blocking workers, serialize lifecycle transitions, and keep UI meter reads from waiting on device locks.
+- SEC-001: Do not log setting values or audio. Do not bypass validation for settings writes. Preserve private file modes and completed audio.
+- CON-001: Keep hosted streaming transcription, source-grounded recommendations, macOS support, and current dependencies.
+- CON-002: Do not switch devices within an existing WAV recording. Different hardware formats require segmented recordings or a continuous format conversion design first.
+
+## 2. Implementation steps
+
+### Implementation phase 1
+
+- GOAL-001: Complete the shipped-change fit assessment. Completion: each release entry has a decision in the review table below.
+
+| Task     | Description                                                                                                                                                   | Completed | Date       |
+| -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- | ---------- |
+| TASK-001 | Inspect all v0.9 release notes and the implementation diffs for audio, settings, overlay, tray, and login-item candidates. Record source links and decisions. | Yes       | 2026-09-05 |
+
+### Implementation phase 2
+
+- GOAL-002: Apply compatible reliability fixes. Depends on Phase 1. Completion: regression checks pass for each changed behavior.
+
+| Task     | Description                                                                                                                                                                   | Completed | Date       |
+| -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- | ---------- |
+| TASK-002 | In `src-tauri/src/settings.rs::load`, recover independently deserializable fields from object-shaped JSON, then apply existing migrations.                                    | Yes       | 2026-09-05 |
+| TASK-003 | In `src-tauri/src/lib.rs`, broadcast committed settings and apply native theme; in `src/App.tsx`, subscribe to settings and capture-error events.                             | Yes       | 2026-09-05 |
+| TASK-004 | In `src/App.tsx`, unmount idle `MeetingOverlay` and replace overlapping meter intervals with a cancellable, visibility-aware poll.                                            | Yes       | 2026-09-05 |
+| TASK-005 | In `crates/audio/src/lib.rs`, use default microphone when the saved input is absent and report failed capture through meter health; document fallback and Bluetooth behavior. | Yes       | 2026-09-05 |
+| TASK-006 | In `src-tauri/src/lib.rs`, dispatch start/pause/resume/stop and settings work to blocking workers, serialize meeting transitions, and use nonblocking meter lock acquisition. | Yes       | 2026-09-05 |
+
+### Implementation phase 3
+
+- GOAL-003: Verify and record results. Depends on Phase 2. Completion: repository verification passes, with physical hardware checks explicitly separated.
+
+| Task     | Description                                                                                                                                        | Completed | Date       |
+| -------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | --------- | ---------- |
+| TASK-007 | Add regression tests to existing Rust and frontend suites; run `cargo fmt --all --check` and `pnpm verify`. Record results and manual checks here. | Yes       | 2026-09-05 |
+
+### Update and onboarding follow-up
+
+- GOAL-004: Fix the user-reported return to setup after updating. See the [investigation and evidence](../docs/update-permissions-investigation.md).
+
+| Task     | Description                                                                                                                                                                                                                     | Completed | Date       |
+| -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- | ---------- |
+| TASK-008 | Compare actual v0.1.0 and v0.1.1 release signatures, trace Tauri restart and permission checks, and distinguish confirmed causes from inference.                                                                                | Yes       | 2026-09-05 |
+| TASK-009 | In `src/App.tsx`, remove the completed-user startup permission gate. Keep microphone enforcement at meeting start.                                                                                                              | Yes       | 2026-09-05 |
+| TASK-010 | Add `src-tauri/src/relaunch.rs`; route updates and explicit permission recovery through Launch Services after process exit. Block restarting during meetings and show failures.                                                 | Yes       | 2026-09-05 |
+| TASK-011 | Add an explicit ScreenCaptureKit recheck through `crates/audio/src/lib.rs`, `src-tauri/src/lib.rs`, and `src/lib/api.ts`; expose recheck/reopen recovery in `src/Onboarding.tsx` with regressions in `src/Onboarding.test.tsx`. | Yes       | 2026-09-05 |
+
+## 3. Alternatives
+
+- ALT-001: Direct upstream merge. Rejected because Savvy's hosted transcription, meeting records, recommendation providers, and UI use different implementations.
+- ALT-002: Local streaming model migration from Handy #1529/#1924. Defer to a dedicated offline transcription project with model downloads, packaging, language coverage, and two-stream performance evaluation.
+- ALT-003: Mid-meeting device recovery from #1838/#1874. Adapt health reporting and next-recording fallback now. Defer automatic switching until the recording format can change without invalidating the current WAV.
+- ALT-004: SMAppService from #1825. Defer. Launch at login already works through Tauri; changing registration requires migration and signed installed-app verification. The upstream benefit is app attribution in Login Items.
+- ALT-005: New tray state engine from #1952. Skip. Savvy uses one static template image and does not have Handy's competing model/recording/theme icon writers.
+- ALT-006: FFT meter calibration from #1813/#1491. Skip the constants. Savvy measures RMS and already scales its display, so Handy's per-bin FFT correction is not applicable.
+
+## 4. Dependencies
+
+- DEP-001: Existing serde_json, CPAL, Tauri, React, and Vitest. No added package dependencies.
+- DEP-002: Existing pinned Rust toolchain and pnpm lockfile, with macOS and Xcode command-line tools for native compilation.
+
+## 5. Files
+
+- FILE-001: `src-tauri/src/settings.rs`, settings salvage and regression test.
+- FILE-002: `src-tauri/src/lib.rs`, settings events, native theme, worker dispatch, and capture health.
+- FILE-003: `crates/audio/src/lib.rs`, microphone fallback and capture errors.
+- FILE-004: `src/App.tsx` and `src/App.test.tsx`, settings subscription, overlay lifecycle, polling, and regression checks.
+- FILE-005: `README.md`, microphone fallback and Bluetooth guidance.
+- FILE-006: This plan, upstream decisions and verification record.
+- FILE-007: `src-tauri/src/relaunch.rs`, `src/Onboarding.tsx`, `src/Onboarding.test.tsx`, and `src/lib/api.ts`, update/permission recovery.
+- FILE-008: `docs/update-permissions-investigation.md`, incident investigation, artifact verification, and limits.
+- FILE-009: `src-tauri/src/tray.rs`, route quit through worker-thread cleanup.
+- FILE-010: App manifests and `Cargo.lock`, patch version 0.1.2. Browser preview reads the package version.
+- FILE-011: `CONTRIBUTING.md` and the local install script, correct outdated platform and updater comments.
+
+## 6. Testing
+
+- TEST-001: Invalid field types must not reset the microphone, theme, onboarding, or custom prompt. Non-object JSON retains fresh defaults. Legacy migrations still run.
+- TEST-002: Device resolution prefers a present selected device, falls back only for missing input, and reports missing output or default devices.
+- TEST-003: Idle overlay has no animated card. Polling stops on pause/unmount/hidden documents, handles rejection, and never overlaps slow requests.
+- TEST-004: A saved settings event updates the overlay theme and display settings without relaunching.
+- TEST-005: Run `pnpm verify` and Rust formatting; inspect the final diff for unrelated edits.
+- TEST-006: Manual installed-app checks: unplug selected USB/Bluetooth input before starting; disconnect during recording and verify an actionable error; stop and start again; toggle Light/Dark/System; confirm responsive start/pause/stop and intact audio; quit while settings are saving. Automated tests do not establish these hardware results.
+
+## 7. Risks and assumptions
+
+- RISK-001: Automatic fallback can select a different microphone than expected. Preserve the preferred device for when it reconnects and document that fallback is per recording.
+- RISK-002: Settings recovery salvages structurally valid JSON objects; it cannot reconstruct truncated JSON. Existing write validation remains authoritative for new settings.
+- RISK-003: Native device and window behavior requires physical macOS testing beyond unit tests and builds.
+- ASSUMPTION-001: The repository's product name is Savvy, referred to as SAVI in the request. Preserve existing branding.
+- ASSUMPTION-002: Recent shipped improvements means the complete v0.9 release series. Older v0.8.3 was checked as context, not treated as newly shipped.
+
+## 8. Sources
+
+- [Handy releases](https://github.com/cjpais/Handy/releases)
+- [Latest stable v0.9.6](https://github.com/cjpais/Handy/releases/tag/v0.9.6)
+- [Settings salvage](https://github.com/cjpais/Handy/pull/1631)
+- [Theme propagation](https://github.com/cjpais/Handy/pull/1659)
+- [Hidden overlay rendering](https://github.com/cjpais/Handy/pull/1445)
+- [Microphone fallback](https://github.com/cjpais/Handy/pull/1874)
+- [Blocking audio work](https://github.com/cjpais/Handy/pull/1716)
+- [Contribution and verification rules](../CONTRIBUTING.md)
+
+### Shipped-change review
+
+Every one of the 116 PR entries in the seven v0.9 release notes is accounted for below. Grouped rows contain changes sharing the same applicability decision. Detailed patches were inspected for the audio, settings, overlay, tray, and login-item candidates. Platform/model-only changes were assessed against Savvy's dependencies and feature set.
+
+<!-- prettier-ignore -->
+| Upstream PRs | Decision | Savvy assessment |
+| --- | --- | --- |
+| [#1631](https://github.com/cjpais/Handy/pull/1631) | Apply | Recover valid settings fields. Savvy already defaults missing fields but reset everything on one wrongly typed field. |
+| [#1659](https://github.com/cjpais/Handy/pull/1659) | Apply | Broadcast saved settings to all webviews and apply native Light/Dark/System appearance. |
+| [#1445](https://github.com/cjpais/Handy/pull/1445) | Apply | Unmount the idle overlay; pause microphone polling for hidden documents. |
+| [#1716](https://github.com/cjpais/Handy/pull/1716) | Apply | Device enumeration already uses workers. Move meeting lifecycle and settings operations to workers too; serialize transitions and avoid blocking meter reads. |
+| [#1874](https://github.com/cjpais/Handy/pull/1874), [#1838](https://github.com/cjpais/Handy/pull/1838) | Adapt | Use the system default at the next recording if the selected input is missing. Surface capture failure; keep existing audio. Automatic mid-recording switching is deferred because WAV format is fixed. |
+| [#1886](https://github.com/cjpais/Handy/pull/1886) | Apply documentation | Explain Bluetooth microphone/playback quality and selecting a separate input. |
+| [#1810](https://github.com/cjpais/Handy/pull/1810) | Already present | Overlay show and resize dispatch to the main thread in src-tauri/src/overlay.rs. Tauri handles hide through its window API. |
+| [#1254](https://github.com/cjpais/Handy/pull/1254) | Already present | selectedChannel exists in settings, UI, capture, and channel-extraction tests. |
+| [#1599](https://github.com/cjpais/Handy/pull/1599) | Already present | Light/Dark/System selector and shared CSS exist. Cross-window propagation is handled above. |
+| [#1310](https://github.com/cjpais/Handy/pull/1310) | Already present | Brief generation and recommendations explicitly treat source text and CONTEXT_JSON as untrusted data; structured results validate evidence references. |
+| [#1537](https://github.com/cjpais/Handy/pull/1537) | Already present | Transcription parsers discard empty turns. Do not suppress manually requested advice based on transcript emptiness. |
+| [#1444](https://github.com/cjpais/Handy/pull/1444), [#1447](https://github.com/cjpais/Handy/pull/1447) | Already present, strengthen | Savvy polls scalar RMS levels instead of pushing audio-callback events to every webview. Bound requests and handle failures in the overlay. |
+| [#1811](https://github.com/cjpais/Handy/pull/1811) | Already present | set_shortcut_recording unregisters the active shortcut while editing it. |
+| [#1908](https://github.com/cjpais/Handy/pull/1908), [#1924](https://github.com/cjpais/Handy/pull/1924), [#1773](https://github.com/cjpais/Handy/pull/1773), [#1668](https://github.com/cjpais/Handy/pull/1668), [#1846](https://github.com/cjpais/Handy/pull/1846), [#1815](https://github.com/cjpais/Handy/pull/1815), [#1731](https://github.com/cjpais/Handy/pull/1731), [#1678](https://github.com/cjpais/Handy/pull/1678), [#1685](https://github.com/cjpais/Handy/pull/1685), [#1662](https://github.com/cjpais/Handy/pull/1662), [#1648](https://github.com/cjpais/Handy/pull/1648), [#1653](https://github.com/cjpais/Handy/pull/1653), [#1664](https://github.com/cjpais/Handy/pull/1664), [#1589](https://github.com/cjpais/Handy/pull/1589), [#1602](https://github.com/cjpais/Handy/pull/1602), [#1603](https://github.com/cjpais/Handy/pull/1603), [#1613](https://github.com/cjpais/Handy/pull/1613), [#1634](https://github.com/cjpais/Handy/pull/1634), [#1484](https://github.com/cjpais/Handy/pull/1484), [#1541](https://github.com/cjpais/Handy/pull/1541), [#1529](https://github.com/cjpais/Handy/pull/1529), [#1522](https://github.com/cjpais/Handy/pull/1522), [#1187](https://github.com/cjpais/Handy/pull/1187) | Defer local model project | These changes concern local inference engines, their models, model downloads, GPU selection, packaging, native model paths, or inference diagnostics. Savvy streams audio to Deepgram/AssemblyAI and has no corresponding model manager. |
+| [#1738](https://github.com/cjpais/Handy/pull/1738), [#1911](https://github.com/cjpais/Handy/pull/1911), [#1406](https://github.com/cjpais/Handy/pull/1406), [#1231](https://github.com/cjpais/Handy/pull/1231), [#1760](https://github.com/cjpais/Handy/pull/1760), [#1785](https://github.com/cjpais/Handy/pull/1785), [#1809](https://github.com/cjpais/Handy/pull/1809), [#1812](https://github.com/cjpais/Handy/pull/1812), [#1847](https://github.com/cjpais/Handy/pull/1847), [#1569](https://github.com/cjpais/Handy/pull/1569), [#1623](https://github.com/cjpais/Handy/pull/1623), [#1465](https://github.com/cjpais/Handy/pull/1465), [#1605](https://github.com/cjpais/Handy/pull/1605), [#1926](https://github.com/cjpais/Handy/pull/1926), [#1708](https://github.com/cjpais/Handy/pull/1708) | Skip dictation-specific behavior | Savvy does not paste text, alter the clipboard, mute system output, run Handy post-processing HTTP requests, correct custom dictation words, use Handy Keys, or provide push-to-talk. Muting system output would impair hearing the meeting. |
+| [#1866](https://github.com/cjpais/Handy/pull/1866), [#1756](https://github.com/cjpais/Handy/pull/1756), [#1412](https://github.com/cjpais/Handy/pull/1412), [#1700](https://github.com/cjpais/Handy/pull/1700), [#1892](https://github.com/cjpais/Handy/pull/1892), [#369](https://github.com/cjpais/Handy/pull/369), [#1733](https://github.com/cjpais/Handy/pull/1733), [#1778](https://github.com/cjpais/Handy/pull/1778), [#1824](https://github.com/cjpais/Handy/pull/1824), [#1561](https://github.com/cjpais/Handy/pull/1561), [#1753](https://github.com/cjpais/Handy/pull/1753), [#1237](https://github.com/cjpais/Handy/pull/1237), [#1308](https://github.com/cjpais/Handy/pull/1308), [#1487](https://github.com/cjpais/Handy/pull/1487), [#1867](https://github.com/cjpais/Handy/pull/1867), [#1727](https://github.com/cjpais/Handy/pull/1727), [#1732](https://github.com/cjpais/Handy/pull/1732), [#1577](https://github.com/cjpais/Handy/pull/1577), [#1621](https://github.com/cjpais/Handy/pull/1621), [#1636](https://github.com/cjpais/Handy/pull/1636), [#1335](https://github.com/cjpais/Handy/pull/1335), [#1392](https://github.com/cjpais/Handy/pull/1392), [#1426](https://github.com/cjpais/Handy/pull/1426) | Skip unsupported platform paths | Linux/Wayland/Nix, Windows, or portable-installer implementation. Savvy ships macOS Apple Silicon and has different CI and packaging. |
+| [#1881](https://github.com/cjpais/Handy/pull/1881), [#1907](https://github.com/cjpais/Handy/pull/1907), [#1747](https://github.com/cjpais/Handy/pull/1747), [#1795](https://github.com/cjpais/Handy/pull/1795), [#1798](https://github.com/cjpais/Handy/pull/1798), [#1697](https://github.com/cjpais/Handy/pull/1697), [#1701](https://github.com/cjpais/Handy/pull/1701), [#1709](https://github.com/cjpais/Handy/pull/1709), [#1590](https://github.com/cjpais/Handy/pull/1590), [#1593](https://github.com/cjpais/Handy/pull/1593), [#1594](https://github.com/cjpais/Handy/pull/1594), [#1604](https://github.com/cjpais/Handy/pull/1604), [#1632](https://github.com/cjpais/Handy/pull/1632), [#1422](https://github.com/cjpais/Handy/pull/1422) | Defer localization project | Handy translation dictionaries cannot be imported into Savvy, whose UI and strings differ and currently have no translation framework. |
+| [#1952](https://github.com/cjpais/Handy/pull/1952), [#1158](https://github.com/cjpais/Handy/pull/1158), [#1355](https://github.com/cjpais/Handy/pull/1355) | Skip tray engine | Savvy has one static template icon, no competing dynamic icon writers, and fallible tray setup. No equivalent per-transition icon panic to patch. |
+| [#1548](https://github.com/cjpais/Handy/pull/1548), [#1823](https://github.com/cjpais/Handy/pull/1823) | Skip HTTP LLM transport | Savvy uses CLI-based recommendations and WebSocket transcription; it does not use Handy's OpenAI-compatible HTTP client. |
+| [#1883](https://github.com/cjpais/Handy/pull/1883), [#1393](https://github.com/cjpais/Handy/pull/1393) | Skip repository-specific documentation | Handy README/agent-workflow edits do not describe Savvy. Preserve this repository's contributing and verification rules. |
+| [#1889](https://github.com/cjpais/Handy/pull/1889) | Adapt documentation | Document development versus release signing identities and permission recovery. Savvy does not need Handy's Accessibility grant. |
+| [#1720](https://github.com/cjpais/Handy/pull/1720) | Already covered by product UI | Savvy has dedicated General, Models, App, and Debug views. Handy sidebar layout is not a behavioral fix for them. |
+| [#1813](https://github.com/cjpais/Handy/pull/1813), [#1491](https://github.com/cjpais/Handy/pull/1491) | Skip FFT constants | Savvy measures RMS, not FFT bins. Its existing scaling should be evaluated on physical microphones rather than copying unrelated decibel constants. |
+| [#1779](https://github.com/cjpais/Handy/pull/1779) | Defer low-priority UI | Savvy has one feedback-volume slider with its current percentage shown. A reset control can be added with a broader settings-reset request. |
+| [#1825](https://github.com/cjpais/Handy/pull/1825) | Defer installed-app migration | SMAppService improves Login Items attribution. Current launch-at-login works through Tauri; migration needs signed-bundle tests and careful removal of the old LaunchAgent. |
+| [#1822](https://github.com/cjpais/Handy/pull/1822) | Not applicable | Savvy has no What's New view or markdown-renderer dependency in settings. |
+| [#1865](https://github.com/cjpais/Handy/pull/1865) | Already covered | The pnpm lockfile already resolves js-yaml 4.3.1; no upgrade necessary for the upstream quadratic omap fix. |
+| [#1675](https://github.com/cjpais/Handy/pull/1675) | Partly present | Cargo.lock already pins Tauri 2.11.5. Savvy's close-to-hide and reopen window behavior is implemented separately in tray.rs. |
+| [#1665](https://github.com/cjpais/Handy/pull/1665) | Not applicable | Savvy exposes recording/transcript files rather than multiple embedded audio players. |
+| [#1582](https://github.com/cjpais/Handy/pull/1582) | Defer caching | Avoid introducing device/configuration caches into Savvy's per-meeting capture. Worker dispatch addresses UI blocking without stale cached hardware state. |
+| [#1597](https://github.com/cjpais/Handy/pull/1597) | Already covered | Savvy uses streaming transcript and explicit checking/thinking recommendation phases; it has no local non-streaming recognition phase. |
+| [#1510](https://github.com/cjpais/Handy/pull/1510) | Not applicable | No Apple Intelligence/Swift AI bridge exists in Savvy's build. Command Line Tools are already documented. |
+| [#1344](https://github.com/cjpais/Handy/pull/1344) | Not applicable to resampler | Savvy's transcription resample_linear function is stateless and creates no retained resampler history to clear. |
+| [#1354](https://github.com/cjpais/Handy/pull/1354) | Not applicable to upstream destructor | Savvy has no Handy recorder/audio-manager Drop implementation or unwrap-on-poison in that destructor path. |
+| [#1614](https://github.com/cjpais/Handy/pull/1614) | Already present | Recommendation coordination cancels pending generations and terminates CLI work on pause/stop; output deadlines already exist. |
+| [#1471](https://github.com/cjpais/Handy/pull/1471) | Already documented | README states Apple Silicon releases and buildable but unsupported Intel. |
+| [#1402](https://github.com/cjpais/Handy/pull/1402) | Not applicable to upstream selector | Handy's model post-processing dropdown does not exist in Savvy. Savvy has its own bounded dropdown menus. |
+| [#1535](https://github.com/cjpais/Handy/pull/1535) | Defer diagnostics UI | Savvy already offers log-directory access. Add a live viewer if file logs prove insufficient for support. |
+
+### Verification results
+
+- `pnpm verify` passed on macOS with the pinned Node, pnpm, and Rust toolchain: formatting, TypeScript, ESLint, 44 frontend tests, 76 Rust tests, production Vite build, and Clippy with warnings denied. Two existing external-provider tests remain ignored.
+- `cargo fmt --all --check`, `git diff --check`, and `cargo deny check` passed.
+- Both published v0.1.0/v0.1.1 updater app bundles passed strict code-signature verification and have matching designated requirements.
+- No dependencies, signing identities, installed applications, user settings, or macOS grants were changed. The app version and its Cargo.lock entry are bumped to 0.1.2 for the PR only.
+- Physical microphone disconnect/reconnect, native theme rendering, and a full signed in-app update cycle remain manual release checks. The implementation is complete; those hardware results are not claimed.
+- This PR includes this review and the permission investigation as specific exceptions to the ignored working-document directories. No release or tag is created.

--- a/scripts/build-install-run-macos.sh
+++ b/scripts/build-install-run-macos.sh
@@ -28,8 +28,8 @@ elif [[ $# -gt 0 ]]; then
 fi
 
 ensure_no_active_meeting
-# Local installs never auto-update, and building updater artifacts would require the
-# updater signing key on every dev machine. Only the release workflow produces them.
+# Skip updater artifacts so local builds do not need the updater signing key.
+# The installed app can still check for published updates.
 (cd "$repo_root" && pnpm tauri build --config '{"bundle":{"createUpdaterArtifacts":false}}')
 signing_identity="${SAVVY_SIGNING_IDENTITY:-$(security find-identity -v -p codesigning | awk -F'"' '/"Apple Development:/ { print $2; exit }')}"
 [[ -n "$signing_identity" ]] || { echo "No Apple Development signing identity found." >&2; exit 1; }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "savvy"
-version = "0.1.1"
+version = "0.1.2"
 description = "Savvy, a meeting assistant grounded in your own sources"
 authors = ["Alamas Labs, Inc."]
 repository = "https://github.com/jamalavedra/savvy"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -61,6 +61,8 @@ use uuid::Uuid;
 
 #[cfg(target_os = "macos")]
 mod overlay;
+#[cfg(target_os = "macos")]
+mod relaunch;
 mod settings;
 #[cfg(target_os = "macos")]
 mod tray;
@@ -106,6 +108,8 @@ struct AppState {
     storage: Mutex<Storage>,
     live_meeting: Mutex<Option<LiveMeeting>>,
     settings: Mutex<AppSettings>,
+    // Serializes capture/settings changes; true blocks new work during restart.
+    app_operation: Mutex<bool>,
     settings_path: PathBuf,
     provider_health: Mutex<Vec<ProviderHealth>>,
     #[cfg(target_os = "macos")]
@@ -701,6 +705,17 @@ fn missing_transcription_key_message(provider: &str) -> String {
 }
 
 #[tauri::command]
+async fn probe_system_audio_permission() -> Result<(), String> {
+    #[cfg(target_os = "macos")]
+    return tauri::async_runtime::spawn_blocking(SystemAudioCapture::check_permission)
+        .await
+        .map_err(|error| error.to_string())?
+        .map_err(|error| error.to_string());
+    #[cfg(not(target_os = "macos"))]
+    Ok(())
+}
+
+#[tauri::command]
 async fn get_input_devices() -> Result<Vec<AudioDevice>, String> {
     #[cfg(target_os = "macos")]
     {
@@ -727,10 +742,14 @@ async fn get_output_devices() -> Result<Vec<AudioDevice>, String> {
 }
 
 #[tauri::command]
-fn update_app_settings(
+async fn update_app_settings(settings: AppSettings, app: AppHandle) -> Result<AppSettings, String> {
+    run_app_command(app, move |app, state| update_settings(settings, app, state)).await
+}
+
+fn update_settings(
     settings: AppSettings,
-    app: AppHandle,
-    state: State<'_, AppState>,
+    app: &AppHandle,
+    state: &AppState,
 ) -> Result<AppSettings, String> {
     validate_settings(&settings)?;
     let previous = state
@@ -738,12 +757,12 @@ fn update_app_settings(
         .lock()
         .map_err(|_| "settings lock poisoned")?
         .clone();
-    if let Err(error) = apply_runtime_settings(&app, &state, &previous, &settings) {
-        let _ = apply_runtime_settings(&app, &state, &settings, &previous);
+    if let Err(error) = apply_runtime_settings(app, state, &previous, &settings) {
+        let _ = apply_runtime_settings(app, state, &settings, &previous);
         return Err(error);
     }
     if let Err(error) = settings::save(&state.settings_path, &settings) {
-        let _ = apply_runtime_settings(&app, &state, &settings, &previous);
+        let _ = apply_runtime_settings(app, state, &settings, &previous);
         return Err(error);
     }
     *state
@@ -751,7 +770,10 @@ fn update_app_settings(
         .lock()
         .map_err(|_| "settings lock poisoned")? = settings.clone();
     #[cfg(target_os = "macos")]
-    tray::update_shortcut_label(&app, &settings.start_listening_shortcut);
+    tray::update_shortcut_label(app, &settings.start_listening_shortcut);
+    if let Err(error) = app.emit("savvy://settings-changed", &settings) {
+        log::warn!("could not notify windows of saved settings: {error}");
+    }
     Ok(settings)
 }
 
@@ -771,6 +793,9 @@ fn apply_runtime_settings(
             .map_err(|_| "microphone lock poisoned")?
             .configure(next.selected_microphone.clone(), next.selected_channel)
             .map_err(|error| error.to_string())?;
+    }
+    if next.theme != current.theme {
+        apply_native_theme(app, &next.theme);
     }
     if next.start_listening_shortcut != current.start_listening_shortcut {
         replace_start_shortcut(
@@ -793,6 +818,14 @@ fn apply_runtime_settings(
         tray::set_visible(app, next.show_tray_icon)?;
     }
     Ok(())
+}
+
+fn apply_native_theme(app: &AppHandle, theme: &str) {
+    app.set_theme(match theme {
+        "light" => Some(tauri::Theme::Light),
+        "dark" => Some(tauri::Theme::Dark),
+        _ => None,
+    });
 }
 
 /// Manual check from the footer button. Returns whether an update was offered, so the
@@ -2276,11 +2309,41 @@ fn refresh_brief_from_document(
 }
 
 #[tauri::command]
-fn start_meeting(
+async fn start_meeting(
     client_id: Option<String>,
     brief_id: Option<String>,
     app: AppHandle,
-    state: State<'_, AppState>,
+) -> Result<MeetingSession, String> {
+    run_app_command(app, move |app, state| {
+        start_meeting_inner(client_id, brief_id, app, state)
+    })
+    .await
+}
+
+async fn run_app_command<T: Send + 'static>(
+    app: AppHandle,
+    operation: impl FnOnce(&AppHandle, &AppState) -> Result<T, String> + Send + 'static,
+) -> Result<T, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let state = app.state::<AppState>();
+        let operation_guard = state
+            .app_operation
+            .try_lock()
+            .map_err(|_| "an application operation is already in progress")?;
+        if *operation_guard {
+            return Err("Savvy is reopening; try again after it opens".into());
+        }
+        operation(&app, &state)
+    })
+    .await
+    .map_err(|error| error.to_string())?
+}
+
+fn start_meeting_inner(
+    client_id: Option<String>,
+    brief_id: Option<String>,
+    app: &AppHandle,
+    state: &AppState,
 ) -> Result<MeetingSession, String> {
     log::info!("meeting start requested");
     let client_id = client_id
@@ -2337,7 +2400,7 @@ fn start_meeting(
         general_guidelines_brief(&settings)
     };
     brief.response_language = recommendation_language(&meeting_language);
-    let context_pack = build_context_pack(&state, client_id, brief_id, &brief, &meeting_language)?;
+    let context_pack = build_context_pack(state, client_id, brief_id, &brief, &meeting_language)?;
     let session = MeetingSession {
         id: Uuid::new_v4(),
         client_id,
@@ -2351,7 +2414,7 @@ fn start_meeting(
     };
     #[cfg(target_os = "macos")]
     let session = {
-        let path = recordings_directory(&state)?.join(format!("{}.wav", session.id));
+        let path = recordings_directory(state)?.join(format!("{}.wav", session.id));
         let mut microphone = state
             .microphone
             .lock()
@@ -2370,7 +2433,7 @@ fn start_meeting(
     #[cfg(target_os = "macos")]
     log::info!("microphone capture started");
     #[cfg(target_os = "macos")]
-    play_configured_feedback(&state, true);
+    play_configured_feedback(state, true);
     {
         let storage = state.storage.lock().map_err(|_| "storage lock poisoned")?;
         if let Err(error) = storage.save_session(&session) {
@@ -2408,9 +2471,9 @@ fn start_meeting(
         .lock()
         .map_err(|_| "meeting lock poisoned")? = Some(live);
     #[cfg(target_os = "macos")]
-    prepare_providers(&app, &state, session.id);
+    prepare_providers(app, state, session.id);
     #[cfg(target_os = "macos")]
-    if let Err(error) = start_transcription_worker(&app, &state, session.id) {
+    if let Err(error) = start_transcription_worker(app, state, session.id) {
         log::error!("live transcription unavailable: {error}");
         let _ = app.emit(
             "meeting://provider-error",
@@ -2424,7 +2487,7 @@ fn start_meeting(
             .lock()
             .map_err(|_| "settings lock poisoned")?
             .clone();
-        overlay::show(&app, &settings);
+        overlay::show(app, &settings);
     }
     app.emit("meeting://session", &session)
         .map_err(|error| error.to_string())?;
@@ -3549,8 +3612,8 @@ fn emit_interim_transcript(app: &AppHandle, session_id: Uuid, transcript: LiveTr
 fn set_meeting_listening(
     session_id: String,
     listening: bool,
-    app: AppHandle,
-    state: State<'_, AppState>,
+    app: &AppHandle,
+    state: &AppState,
 ) -> Result<MeetingSession, String> {
     let session_id = Uuid::parse_str(&session_id).map_err(|error| error.to_string())?;
     let target = if listening {
@@ -3575,9 +3638,9 @@ fn set_meeting_listening(
         return Err("meeting is already in the requested state".into());
     }
     if !listening {
-        cancel_active_generation(&app, live);
+        cancel_active_generation(app, live);
         #[cfg(target_os = "macos")]
-        cancel_reasoning(&state);
+        cancel_reasoning(state);
     }
     #[cfg(target_os = "macos")]
     {
@@ -3619,38 +3682,46 @@ fn set_meeting_listening(
 }
 
 #[tauri::command]
-fn pause_meeting(
-    session_id: String,
-    app: AppHandle,
-    state: State<'_, AppState>,
-) -> Result<MeetingSession, String> {
-    set_meeting_listening(session_id, false, app, state)
+async fn pause_meeting(session_id: String, app: AppHandle) -> Result<MeetingSession, String> {
+    run_app_command(app, move |app, state| {
+        set_meeting_listening(session_id, false, app, state)
+    })
+    .await
 }
 
 #[tauri::command]
-fn resume_meeting(
-    session_id: String,
-    app: AppHandle,
-    state: State<'_, AppState>,
-) -> Result<MeetingSession, String> {
-    set_meeting_listening(session_id, true, app, state)
+async fn resume_meeting(session_id: String, app: AppHandle) -> Result<MeetingSession, String> {
+    run_app_command(app, move |app, state| {
+        set_meeting_listening(session_id, true, app, state)
+    })
+    .await
 }
 
 #[tauri::command]
-fn stop_meeting(
-    session_id: String,
-    app: AppHandle,
-    state: State<'_, AppState>,
-) -> Result<MeetingSession, String> {
-    log::info!("meeting stop requested");
+async fn stop_meeting(session_id: String, app: AppHandle) -> Result<MeetingSession, String> {
     let session_id = Uuid::parse_str(&session_id).map_err(|error| error.to_string())?;
-    stop_live_meeting(&app, &state, session_id)
+    run_app_command(app, move |app, state| {
+        stop_live_meeting(app, state, session_id)
+    })
+    .await
 }
 
-/// Stops whatever meeting is live before the process exits, so quitting never
-/// leaves a session recorded as still running.
-pub(crate) fn stop_active_meeting(app: &AppHandle) {
+/// Keep the event loop free while capture or settings work finishes before exit.
+pub(crate) fn quit(app: &AppHandle) {
+    let app = app.clone();
+    tauri::async_runtime::spawn_blocking(move || {
+        stop_active_meeting(&app);
+        app.exit(0);
+    });
+}
+
+fn stop_active_meeting(app: &AppHandle) {
     let state = app.state::<AppState>();
+    let mut operation = state
+        .app_operation
+        .lock()
+        .unwrap_or_else(|error| error.into_inner());
+    *operation = true;
     let session_id = state
         .live_meeting
         .lock()
@@ -3761,11 +3832,11 @@ fn cancel_reasoning(state: &AppState) {
 fn get_audio_level(state: State<'_, AppState>) -> Result<f32, String> {
     #[cfg(target_os = "macos")]
     {
-        state
-            .microphone
-            .lock()
-            .map(|microphone| microphone.level())
-            .map_err(|_| "microphone lock poisoned".to_owned())
+        match state.microphone.try_lock() {
+            Ok(microphone) => microphone.level().map_err(|error| error.to_string()),
+            Err(std::sync::TryLockError::WouldBlock) => Ok(0.0),
+            Err(std::sync::TryLockError::Poisoned(_)) => Err("microphone lock poisoned".into()),
+        }
     }
     #[cfg(not(target_os = "macos"))]
     {
@@ -4897,6 +4968,54 @@ fn update_check_outcome(
     }
 }
 
+fn prepare_to_relaunch(app: &AppHandle) -> Result<(), String> {
+    let state = app.state::<AppState>();
+    let mut operation = state
+        .app_operation
+        .try_lock()
+        .map_err(|_| "Wait for the current meeting operation to finish.")?;
+    if *operation {
+        return Err("Savvy is already updating or reopening.".into());
+    }
+    if state
+        .live_meeting
+        .lock()
+        .map_err(|_| "meeting lock poisoned")?
+        .is_some()
+    {
+        return Err("Stop the meeting before updating or reopening Savvy.".into());
+    }
+    *operation = true;
+    Ok(())
+}
+
+fn cancel_relaunch(app: &AppHandle) {
+    if let Ok(mut operation) = app.state::<AppState>().app_operation.lock() {
+        *operation = false;
+    }
+}
+
+fn finish_relaunch(app: &AppHandle) -> Result<(), String> {
+    #[cfg(target_os = "macos")]
+    {
+        relaunch::schedule(app)?;
+        app.exit(0);
+    }
+    #[cfg(not(target_os = "macos"))]
+    app.request_restart();
+    Ok(())
+}
+
+#[tauri::command]
+fn reopen_app(app: AppHandle) -> Result<(), String> {
+    prepare_to_relaunch(&app)?;
+    if let Err(error) = finish_relaunch(&app) {
+        cancel_relaunch(&app);
+        return Err(error);
+    }
+    Ok(())
+}
+
 fn offer_update(app: tauri::AppHandle, update: tauri_plugin_updater::Update) {
     let version = update.version.clone();
     let handle = app.clone();
@@ -4915,12 +5034,28 @@ fn offer_update(app: tauri::AppHandle, update: tauri_plugin_updater::Update) {
             if !accepted {
                 return;
             }
+            if let Err(error) = prepare_to_relaunch(&handle) {
+                handle
+                    .dialog()
+                    .message(error)
+                    .title("Update postponed")
+                    .show(|_| {});
+                return;
+            }
             tauri::async_runtime::spawn(async move {
-                if let Err(error) = update.download_and_install(|_, _| {}, || {}).await {
-                    log::error!("could not install update {version}: {error}");
-                    return;
+                let result = match update.download_and_install(|_, _| {}, || {}).await {
+                    Ok(()) => finish_relaunch(&handle),
+                    Err(error) => Err(format!("could not install update {version}: {error}")),
+                };
+                if let Err(error) = result {
+                    cancel_relaunch(&handle);
+                    log::error!("{error}");
+                    handle
+                        .dialog()
+                        .message(error)
+                        .title("Update failed")
+                        .show(|_| {});
                 }
-                handle.restart();
             });
         });
 }
@@ -4954,11 +5089,11 @@ pub fn run() {
         .setup(|app| {
             let app_data = app.path().app_data_dir()?;
             create_private_directory(&app_data)?;
-            spawn_update_check(app.handle().clone());
             let recordings = app_data.join("recordings");
             create_private_directory(&recordings)?;
             let settings_path = app_data.join("settings.json");
             let mut settings = settings::load(&settings_path);
+            apply_native_theme(app.handle(), &settings.theme);
             let provider_health = recommendation_provider_status();
             #[cfg(target_os = "macos")]
             if let Ok(provider) =
@@ -5004,6 +5139,7 @@ pub fn run() {
                 storage: Mutex::new(storage),
                 live_meeting: Mutex::new(None),
                 settings: Mutex::new(settings.clone()),
+                app_operation: Mutex::new(false),
                 settings_path,
                 provider_health: Mutex::new(provider_health),
                 #[cfg(target_os = "macos")]
@@ -5038,6 +5174,7 @@ pub fn run() {
                     }
                 }
             }
+            spawn_update_check(app.handle().clone());
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
@@ -5050,8 +5187,10 @@ pub fn run() {
             set_transcription_api_key,
             delete_transcription_api_key,
             get_input_devices,
+            probe_system_audio_permission,
             get_output_devices,
             check_for_updates,
+            reopen_app,
             set_shortcut_recording,
             set_overlay_expanded,
             get_dashboard,
@@ -5082,7 +5221,13 @@ pub fn run() {
     app.run(|app, event| match event {
         #[cfg(target_os = "macos")]
         tauri::RunEvent::Reopen { .. } => tray::show_main_window(app),
-        tauri::RunEvent::ExitRequested { .. } => stop_active_meeting(app),
+        // Programmatic exits have already stopped capture or rejected an active meeting.
+        tauri::RunEvent::ExitRequested {
+            code: None, api, ..
+        } => {
+            api.prevent_exit();
+            quit(app);
+        }
         _ => {}
     });
 }

--- a/src-tauri/src/relaunch.rs
+++ b/src-tauri/src/relaunch.rs
@@ -1,0 +1,93 @@
+use std::{
+    path::Path,
+    process::{Command, Stdio},
+};
+use tauri::{AppHandle, Manager};
+
+// Launch Services starts the replacement bundle after the old process exits.
+// Directly spawning Contents/MacOS/savvy inherits the old process's launch context.
+const WAIT_AND_EXEC: &str = r#"
+while kill -0 "$1" 2>/dev/null; do sleep 0.1; done
+shift
+exec "$@"
+"#;
+
+fn app_bundle(binary: &Path) -> Option<&Path> {
+    let macos = binary.parent()?;
+    let contents = macos.parent()?;
+    let bundle = contents.parent()?;
+    (macos.file_name()? == "MacOS"
+        && contents.file_name()? == "Contents"
+        && bundle.extension()? == "app")
+        .then_some(bundle)
+}
+
+pub fn schedule(app: &AppHandle) -> Result<(), String> {
+    let binary = tauri::process::current_binary(&app.env()).map_err(|error| error.to_string())?;
+    let bundle =
+        app_bundle(&binary).ok_or("Reopen Savvy from its installed application bundle.")?;
+    Command::new("/bin/sh")
+        .args(["-c", WAIT_AND_EXEC, "savvy-relaunch"])
+        .arg(std::process::id().to_string())
+        .args(["/usr/bin/open", "-n"])
+        .arg(bundle)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .map_err(|error| format!("could not schedule Savvy to reopen: {error}"))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{
+        fs, thread,
+        time::{Duration, Instant},
+    };
+
+    #[test]
+    fn relaunch_waits_for_exit_and_preserves_literal_arguments() {
+        assert_eq!(
+            app_bundle(Path::new("/Applications/Savvy.app/Contents/MacOS/savvy")),
+            Some(Path::new("/Applications/Savvy.app"))
+        );
+        assert!(app_bundle(Path::new("/tmp/target/debug/savvy")).is_none());
+        let path = std::env::temp_dir().join(format!("savvy-relaunch-{}", uuid::Uuid::new_v4()));
+        let mut old = Command::new("/bin/sleep").arg("30").spawn().unwrap();
+        let literal = "/Applications/Savvy's $(touch unwanted) app.app";
+        let mut helper = Command::new("/bin/sh")
+            .args(["-c", WAIT_AND_EXEC, "savvy-relaunch"])
+            .arg(old.id().to_string())
+            .args([
+                "/bin/sh",
+                "-c",
+                "printf '%s' \"$1\" > \"$2\"",
+                "test",
+                literal,
+            ])
+            .arg(&path)
+            .spawn()
+            .unwrap();
+        thread::sleep(Duration::from_millis(200));
+        assert!(!path.exists());
+        old.kill().unwrap();
+        old.wait().unwrap();
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            if let Some(status) = helper.try_wait().unwrap() {
+                assert!(status.success());
+                break;
+            }
+            if Instant::now() >= deadline {
+                let _ = helper.kill();
+                let _ = helper.wait();
+                panic!("relaunch helper did not finish");
+            }
+            thread::sleep(Duration::from_millis(20));
+        }
+        assert_eq!(fs::read_to_string(&path).unwrap(), literal);
+        fs::remove_file(path).unwrap();
+    }
+}

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -65,16 +65,27 @@ impl Default for AppSettings {
 
 pub fn load(path: &Path) -> AppSettings {
     let Ok(bytes) = fs::read(path) else {
-        // No settings file: a fresh install, which should see onboarding.
+        // Missing or unreadable settings use first-run defaults.
         return AppSettings::default();
     };
     let Ok(value) = serde_json::from_slice::<serde_json::Value>(&bytes) else {
         return AppSettings::default();
     };
-    let has_onboarding_flag = value.get("onboardingCompleted").is_some();
-    let Ok(mut settings) = serde_json::from_value::<AppSettings>(value) else {
+    let Some(fields) = value.as_object() else {
         return AppSettings::default();
     };
+    let has_onboarding_flag = fields.contains_key("onboardingCompleted");
+    let mut settings = serde_json::from_value::<AppSettings>(value.clone()).unwrap_or_else(|_| {
+        let mut recovered = serde_json::Map::new();
+        for (key, value) in fields {
+            recovered.insert(key.clone(), value.clone());
+            if serde_json::from_value::<AppSettings>(recovered.clone().into()).is_err() {
+                recovered.remove(key);
+                log::warn!("Ignoring invalid settings field: {key}");
+            }
+        }
+        serde_json::from_value(recovered.into()).unwrap_or_default()
+    });
     if !has_onboarding_flag {
         // Settings written before onboarding existed. The install is already in use,
         // so onboarding it now would be a regression for every current user.
@@ -137,6 +148,30 @@ mod tests {
         });
         assert_eq!(settings.transcription_model, "u3-rt-pro");
         assert_eq!(settings.transcription_language, "multi");
+    }
+
+    #[test]
+    fn invalid_fields_do_not_reset_completed_setup_or_other_preferences() {
+        let directory =
+            std::env::temp_dir().join(format!("savvy-settings-{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(&directory).unwrap();
+        let path = directory.join("settings.json");
+        let stored = br#"{"onboardingCompleted":true,"theme":"dark","selectedMicrophone":"USB mic","audioFeedbackVolume":"bad","selectedChannel":-1,"briefGenerationPrompt":"Keep this prompt","transcriptionProvider":"assemblyAi","transcriptionModel":"universal-3-5-pro"}"#;
+        fs::write(&path, stored).unwrap();
+        let settings = load(&path);
+        assert!(settings.onboarding_completed);
+        assert_eq!(settings.theme, "dark");
+        assert_eq!(settings.selected_microphone.as_deref(), Some("USB mic"));
+        assert_eq!(settings.audio_feedback_volume, 0.5);
+        assert_eq!(settings.selected_channel, None);
+        assert_eq!(settings.brief_generation_prompt, "Keep this prompt");
+        assert_eq!(settings.transcription_model, "u3-rt-pro");
+        assert_eq!(fs::read(&path).unwrap(), stored);
+        for invalid in ["null", "[]", "{broken"] {
+            fs::write(&path, invalid).unwrap();
+            assert!(!load(&path).onboarding_completed);
+        }
+        fs::remove_dir_all(directory).unwrap();
     }
 
     #[test]

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -71,10 +71,7 @@ pub fn setup(app: &mut App, visible: bool) -> tauri::Result<()> {
                 show_main_window(app);
                 let _ = app.emit("savvy://check-updates", ());
             }
-            "quit" => {
-                crate::stop_active_meeting(app);
-                app.exit(0);
-            }
+            "quit" => crate::quit(app),
             _ => {}
         })
         .build(app)?;

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Savvy",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "identifier": "com.alamaslabs.savvy",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,5 +1,12 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { version } from "../package.json";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import App, { MeetingOverlay } from "./App";
 import {
   meetingEventIsStale,
@@ -9,11 +16,119 @@ import {
   type GenerationCursor,
 } from "./lib/meetingEvents";
 import { resetBrowserDemoState } from "./lib/api";
+import * as api from "./lib/api";
+import { listen } from "@tauri-apps/api/event";
+
+vi.mock("@tauri-apps/api/event", () => ({ listen: vi.fn() }));
 import { requestPermissionDecision } from "./lib/permissions";
 import type { TranscriptTurn } from "./types";
 
 describe("App", () => {
-  beforeEach(() => resetBrowserDemoState());
+  beforeEach(() => {
+    resetBrowserDemoState();
+    window.history.replaceState({}, "", "/");
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+    delete window.__TAURI_INTERNALS__;
+    window.history.replaceState({}, "", "/");
+  });
+
+  it("keeps an idle overlay unmounted and applies saved settings from the main window", async () => {
+    const snapshot = await api.getDashboard();
+    const settings = await api.getAppSettings();
+    const preparation = await api.getPreparationSnapshot(null);
+    vi.spyOn(api, "getDashboard").mockResolvedValue(snapshot);
+    vi.spyOn(api, "getAppSettings").mockResolvedValue(settings);
+    vi.spyOn(api, "getAppStatus").mockResolvedValue({
+      version: "0.1.1",
+      platform: "macos",
+    });
+    vi.spyOn(api, "getPreparationSnapshot").mockResolvedValue(preparation);
+    const meter = vi.spyOn(api, "getAudioLevel");
+    vi.mocked(listen).mockResolvedValue(vi.fn());
+    window.__TAURI_INTERNALS__ = {};
+    window.history.replaceState({}, "", "/?overlay=1");
+    const view = render(<App />);
+    await waitFor(() =>
+      expect(listen).toHaveBeenCalledWith(
+        "savvy://settings-changed",
+        expect.any(Function),
+      ),
+    );
+    const handler = vi
+      .mocked(listen)
+      .mock.calls.find(([name]) => name === "savvy://settings-changed")![1];
+    act(() =>
+      handler({
+        event: "savvy://settings-changed",
+        id: 1,
+        payload: { ...settings, theme: "dark" },
+      }),
+    );
+    expect(document.documentElement.dataset.theme).toBe("dark");
+    expect(view.container.querySelector(".ov-stage")).toBeNull();
+    expect(meter).not.toHaveBeenCalled();
+    view.unmount();
+  });
+
+  it("bounds microphone polling and stops it on visibility changes, pause, and unmount", async () => {
+    const session = await api.startMeeting(null, null);
+    const props = {
+      session,
+      turns: [],
+      recommendation: null,
+      onTogglePause: vi.fn(),
+      onRequestRecommendation: vi.fn(),
+      onStop: vi.fn(),
+      busy: false,
+      error: null,
+      style: "live" as const,
+      position: "bottom" as const,
+      showTranscript: false,
+      thinking: null,
+      hasNotes: false,
+    };
+    vi.useFakeTimers();
+    let resolveLevel!: (value: number) => void;
+    const meter = vi.spyOn(api, "getAudioLevel").mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveLevel = resolve;
+      }),
+    );
+    const hidden = vi.spyOn(document, "hidden", "get").mockReturnValue(false);
+    const view = render(<MeetingOverlay {...props} />);
+    await act(() => vi.advanceTimersByTimeAsync(1000));
+    expect(meter).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      resolveLevel(0.1);
+    });
+    hidden.mockReturnValue(true);
+    fireEvent(document, new Event("visibilitychange"));
+    await act(() => vi.advanceTimersByTimeAsync(1000));
+    expect(meter).toHaveBeenCalledTimes(1);
+    meter.mockRejectedValueOnce(new Error("Microphone disconnected"));
+    hidden.mockReturnValue(false);
+    await act(async () => {
+      fireEvent(document, new Event("visibilitychange"));
+    });
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Microphone disconnected",
+    );
+    meter.mockResolvedValue(0.1);
+    await act(() => vi.advanceTimersByTimeAsync(80));
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    view.rerender(
+      <MeetingOverlay {...props} session={{ ...session, state: "paused" }} />,
+    );
+    const calls = meter.mock.calls.length;
+    await act(() => vi.advanceTimersByTimeAsync(1000));
+    expect(meter).toHaveBeenCalledTimes(calls);
+    view.unmount();
+    await act(() => vi.advanceTimersByTimeAsync(1000));
+    expect(meter).toHaveBeenCalledTimes(calls);
+  });
 
   it("tombstones cancelled opportunity results", () => {
     expect(
@@ -436,6 +551,11 @@ describe("App", () => {
   });
 
   it("removes a recommendation when its Keep countdown completes", async () => {
+    const snapshot = await api.getDashboard();
+    vi.spyOn(api, "getDashboard").mockResolvedValue({
+      ...snapshot,
+      activeSession: await api.startMeeting(null, null),
+    });
     window.history.replaceState({}, "", "/?overlay=1");
     render(<App />);
 
@@ -462,6 +582,11 @@ describe("App", () => {
   });
 
   it("can keep a recommendation until it is manually dismissed", async () => {
+    const snapshot = await api.getDashboard();
+    vi.spyOn(api, "getDashboard").mockResolvedValue({
+      ...snapshot,
+      activeSession: await api.startMeeting(null, null),
+    });
     window.history.replaceState({}, "", "/?overlay=1");
     render(<App />);
 
@@ -778,7 +903,7 @@ describe("App", () => {
     expect(screen.getByText("App Data Directory")).toBeVisible();
     expect(screen.getByText("Log Directory")).toBeVisible();
     expect(screen.getAllByRole("button", { name: "Open" })).toHaveLength(2);
-    expect(screen.getAllByText("v0.1.0")).toHaveLength(2);
+    expect(screen.getAllByText(`v${version}`)).toHaveLength(2);
     fireEvent.click(screen.getByRole("button", { name: "Check for updates" }));
     expect(
       await screen.findByRole("button", { name: "Up to date" }),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,6 +33,7 @@ import {
 } from "lucide-react";
 import { listClientDocuments, setClientDocumentSelection } from "./lib/api";
 import "./App.css";
+import { version as appVersion } from "../package.json";
 import mascotListening from "./assets/mascot-states/savvy-listening-upload.png";
 import mascotMuted from "./assets/mascot-states/savvy-muted-upload.png";
 import mascotThinking from "./assets/mascot-states/savvy-thinking.png";
@@ -189,10 +190,8 @@ function App() {
   const [error, setError] = useState<string | null>(null);
   const [appSettings, setAppSettings] = useState<AppSettings | null>(null);
   // null while the check is in flight, so onboarding never flashes on startup.
-  const [onboarding, setOnboarding] = useState<
-    "new" | "returning" | "done" | null
-  >(null);
-  const [version, setVersion] = useState("0.1.0");
+  const [onboarding, setOnboarding] = useState<"new" | "done" | null>(null);
+  const [version, setVersion] = useState(appVersion);
   const [transcriptTurns, setTranscriptTurns] = useState<TranscriptTurn[]>([]);
   const [thinking, setThinking] = useState<ThinkingState>(null);
   const visibleSessionRef = useRef("");
@@ -279,7 +278,7 @@ function App() {
 
   useEffect(() => {
     Promise.all([getAppStatus(), getAppSettings()])
-      .then(async ([status, settings]) => {
+      .then(([status, settings]) => {
         setAppSettings(settings);
         setVersion(status.version);
         document.documentElement.dataset.platform = status.platform;
@@ -287,26 +286,9 @@ function App() {
           setOnboarding("new");
           return;
         }
-        // Already onboarded, but a permission can be revoked at any time. Repair it
-        // up front rather than failing when a meeting is about to start.
-        if (status.platform !== "macos") {
-          setOnboarding("done");
-          return;
-        }
-        try {
-          const { checkMicrophonePermission } =
-            await import("tauri-plugin-macos-permissions-api");
-          // Only the microphone is required. Setup itself lets the user continue
-          // without screen recording, so demanding it here would block the app on
-          // every launch with no way to satisfy it. `startActiveMeeting` asks again
-          // when a meeting needs system audio.
-          setOnboarding(
-            (await checkMicrophonePermission()) ? "done" : "returning",
-          );
-        } catch {
-          // If the permissions cannot be read, do not block the app.
-          setOnboarding("done");
-        }
+        // macOS can return a stale permission result after an update. Completed
+        // setup stays completed; check actual capture access when starting a meeting.
+        setOnboarding("done");
       })
       .catch((reason: unknown) =>
         setError(reason instanceof Error ? reason.message : String(reason)),
@@ -382,6 +364,12 @@ function App() {
     void import("@tauri-apps/api/event")
       .then(({ listen }) =>
         Promise.all([
+          listen<AppSettings>("savvy://settings-changed", (event) =>
+            setAppSettings(event.payload),
+          ),
+          listen<string>("meeting://capture-error", (event) =>
+            setError(event.payload),
+          ),
           listen<MeetingEvent>("meeting://event", (event) =>
             handleMeetingEvent(event.payload),
           ),
@@ -779,17 +767,8 @@ function App() {
   if (!dashboard) return <LoadingState />;
 
   // The overlay window is a separate surface and must never be fronted by setup.
-  if (
-    !overlayWindow &&
-    (onboarding === "new" || onboarding === "returning") &&
-    appSettings
-  ) {
-    return (
-      <Onboarding
-        returningUser={onboarding === "returning"}
-        onComplete={() => void completeOnboarding()}
-      />
-    );
+  if (!overlayWindow && onboarding === "new" && appSettings) {
+    return <Onboarding onComplete={() => void completeOnboarding()} />;
   }
 
   if (
@@ -797,25 +776,28 @@ function App() {
     (!window.__TAURI_INTERNALS__ && dashboard.activeSession)
   ) {
     return (
-      <MeetingOverlay
-        session={dashboard.activeSession}
-        turns={transcriptTurns}
-        recommendation={dashboard.latestRecommendation}
-        onTogglePause={toggleMeetingPause}
-        onRequestRecommendation={forceRecommendation}
-        onStop={endActiveMeeting}
-        busy={busy}
-        error={error}
-        style={appSettings?.overlayStyle ?? "live"}
-        position={appSettings?.overlayPosition ?? "bottom"}
-        showTranscript={appSettings?.showLiveTranscript ?? false}
-        hasNotes={Boolean(
-          dashboard.activeSession?.clientId ||
-          dashboard.activeSession?.briefId ||
-          appSettings?.guidanceFolder,
-        )}
-        thinking={thinking}
-      />
+      dashboard.activeSession && (
+        <MeetingOverlay
+          key={dashboard.activeSession.id}
+          session={dashboard.activeSession}
+          turns={transcriptTurns}
+          recommendation={dashboard.latestRecommendation}
+          onTogglePause={toggleMeetingPause}
+          onRequestRecommendation={forceRecommendation}
+          onStop={endActiveMeeting}
+          busy={busy}
+          error={error}
+          style={appSettings?.overlayStyle ?? "live"}
+          position={appSettings?.overlayPosition ?? "bottom"}
+          showTranscript={appSettings?.showLiveTranscript ?? false}
+          hasNotes={Boolean(
+            dashboard.activeSession?.clientId ||
+            dashboard.activeSession?.briefId ||
+            appSettings?.guidanceFolder,
+          )}
+          thinking={thinking}
+        />
+      )
     );
   }
 
@@ -1869,6 +1851,7 @@ export function MeetingOverlay({
 }) {
   const [elapsed, setElapsed] = useState(0);
   const [audioLevel, setAudioLevel] = useState(0);
+  const [captureError, setCaptureError] = useState<string | null>(null);
   const [confirmingStop, setConfirmingStop] = useState(false);
   const [dismissedRecommendation, setDismissedRecommendation] = useState<
     string | null
@@ -1877,6 +1860,7 @@ export function MeetingOverlay({
     null,
   );
   const transcriptRef = useRef<HTMLDivElement>(null);
+  const sessionId = session?.id;
   const paused = session?.state === "paused";
   const mascot = thinking
     ? { image: mascotThinking, state: "thinking" }
@@ -1891,8 +1875,9 @@ export function MeetingOverlay({
     recommendationKey(recommendation) !== dismissedRecommendation
       ? recommendation
       : null;
+  const displayedError = error ?? captureError;
   const showExtension = Boolean(
-    visibleRecommendation || error || confirmingStop,
+    visibleRecommendation || displayedError || confirmingStop,
   );
   const open = style === "live" && (hasText || showExtension);
   // The card grows vertically whenever `.has-text` or `.ai-open` applies
@@ -1929,17 +1914,44 @@ export function MeetingOverlay({
   }, [session]);
 
   useEffect(() => {
-    if (!session) return;
-    if (paused) return;
-    const timer = window.setInterval(() => {
-      void getAudioLevel().then((level) =>
-        setAudioLevel(
-          (current) => current * 0.6 + Math.min(1, level * 12) * 0.4,
-        ),
-      );
-    }, 80);
-    return () => window.clearInterval(timer);
-  }, [paused, session]);
+    if (!sessionId || paused) return;
+    let stopped = false;
+    let pending = false;
+    let timer: number | undefined;
+    const poll = async () => {
+      if (stopped || pending || document.hidden) return;
+      pending = true;
+      try {
+        const level = await getAudioLevel();
+        if (!stopped) {
+          setCaptureError(null);
+          setAudioLevel(
+            (current) => current * 0.6 + Math.min(1, level * 12) * 0.4,
+          );
+        }
+      } catch (reason) {
+        if (!stopped) {
+          setAudioLevel(0);
+          setCaptureError(String(reason));
+        }
+      } finally {
+        pending = false;
+        if (!stopped && !document.hidden)
+          timer = window.setTimeout(() => void poll(), 80);
+      }
+    };
+    const onVisibility = () => {
+      window.clearTimeout(timer);
+      if (!document.hidden) void poll();
+    };
+    timer = window.setTimeout(() => void poll(), 80);
+    document.addEventListener("visibilitychange", onVisibility);
+    return () => {
+      stopped = true;
+      window.clearTimeout(timer);
+      document.removeEventListener("visibilitychange", onVisibility);
+    };
+  }, [paused, sessionId]);
 
   useEffect(() => {
     if (hasText)
@@ -2033,7 +2045,11 @@ export function MeetingOverlay({
                 </div>
               </div>
             )}
-            {error && <p className="overlay-error">{error}</p>}
+            {displayedError && (
+              <p className="overlay-error" role="alert">
+                {displayedError}
+              </p>
+            )}
           </div>
         </div>
 
@@ -2827,7 +2843,7 @@ function SettingsView({
         <SettingsGroup title="Sound">
           <SettingSelect
             title="Microphone"
-            detail="Select your preferred microphone device."
+            detail="Uses the system default if your preferred microphone is disconnected."
             value={settings.selectedMicrophone ?? ""}
             disabled={saving}
             options={inputs.map((device) => ({

--- a/src/Onboarding.test.tsx
+++ b/src/Onboarding.test.tsx
@@ -14,6 +14,8 @@ const checkMicrophonePermission = vi.fn<() => Promise<boolean>>();
 const checkScreenRecordingPermission = vi.fn<() => Promise<boolean>>();
 const requestMicrophonePermission = vi.fn<() => Promise<void>>();
 const requestScreenRecordingPermission = vi.fn<() => Promise<void>>();
+const probeSystemAudioPermission = vi.fn<() => Promise<void>>();
+const reopenApp = vi.fn<() => Promise<void>>();
 
 vi.mock("tauri-plugin-macos-permissions-api", () => ({
   checkMicrophonePermission: () => checkMicrophonePermission(),
@@ -37,6 +39,8 @@ const setTranscriptionApiKey =
 vi.mock("./lib/api", async (importOriginal) => ({
   ...(await importOriginal<typeof import("./lib/api")>()),
   getAppStatus: () => getAppStatus(),
+  probeSystemAudioPermission: () => probeSystemAudioPermission(),
+  reopenApp: () => reopenApp(),
   getTranscriptionKeyStatus: () => getTranscriptionKeyStatus(),
   setTranscriptionApiKey: (provider: string, key: string) =>
     setTranscriptionApiKey(provider, key),
@@ -79,9 +83,9 @@ function rowButton(title: string) {
   return control;
 }
 
-function renderOnboarding(returningUser = false) {
+function renderOnboarding() {
   const onComplete = vi.fn();
-  render(<Onboarding returningUser={returningUser} onComplete={onComplete} />);
+  render(<Onboarding onComplete={onComplete} />);
   return onComplete;
 }
 
@@ -101,11 +105,44 @@ describe("Onboarding on macOS", () => {
     checkScreenRecordingPermission.mockResolvedValue(false);
     requestMicrophonePermission.mockResolvedValue(undefined);
     requestScreenRecordingPermission.mockResolvedValue(undefined);
+    probeSystemAudioPermission.mockRejectedValue(
+      new Error("Screen capture is unavailable"),
+    );
+    reopenApp.mockResolvedValue(undefined);
   });
 
   afterEach(() => {
     vi.useRealTimers();
     vi.clearAllMocks();
+  });
+
+  it("uses ScreenCaptureKit on an explicit recheck when preflight is stale", async () => {
+    checkMicrophonePermission.mockResolvedValue(true);
+    renderOnboarding();
+    await waitFor(() =>
+      expect(rowButton("Screen & system audio")).toBeEnabled(),
+    );
+    expect(probeSystemAudioPermission).not.toHaveBeenCalled();
+    probeSystemAudioPermission.mockResolvedValueOnce(undefined);
+    fireEvent.click(screen.getByRole("button", { name: "Check again" }));
+    await waitFor(() =>
+      expect(row("Screen & system audio")).toHaveTextContent("Allowed"),
+    );
+    expect(row("Microphone")).toHaveTextContent("Allowed");
+    expect(requestScreenRecordingPermission).not.toHaveBeenCalled();
+  });
+
+  it("offers reopening for an already allowed but still unrecognized permission", async () => {
+    renderOnboarding();
+    await waitFor(() => expect(rowButton("Microphone")).toBeEnabled());
+    fireEvent.click(rowButton("Microphone"));
+    const reopen = await screen.findByRole("button", { name: "Reopen Savvy" });
+    reopenApp.mockRejectedValueOnce(
+      new Error("Stop the meeting before reopening Savvy."),
+    );
+    fireEvent.click(reopen);
+    expect(await findErrorText()).toContain("Stop the meeting");
+    expect(reopenApp).toHaveBeenCalledTimes(1);
   });
 
   it("blocks Continue until the microphone is allowed and says why", async () => {
@@ -317,20 +354,6 @@ describe("Onboarding on macOS", () => {
     expect(await screen.findByText(/Deepgram API key/)).toBeVisible();
     expect(errorText()).toBeNull();
   });
-
-  it("sends a returning user straight back to work once repaired", async () => {
-    checkMicrophonePermission.mockResolvedValue(true);
-    checkScreenRecordingPermission.mockResolvedValue(true);
-    const onComplete = renderOnboarding(true);
-
-    expect(await screen.findByText(/needs its permissions back/)).toBeVisible();
-    await waitFor(() =>
-      expect(screen.getByRole("button", { name: "Continue" })).toBeEnabled(),
-    );
-    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
-    expect(onComplete).toHaveBeenCalled();
-    expect(getTranscriptionKeyStatus).not.toHaveBeenCalled();
-  });
 });
 
 describe("Onboarding gate on relaunch", () => {
@@ -343,19 +366,26 @@ describe("Onboarding gate on relaunch", () => {
     });
     requestMicrophonePermission.mockResolvedValue(undefined);
     requestScreenRecordingPermission.mockResolvedValue(undefined);
+    probeSystemAudioPermission.mockRejectedValue(
+      new Error("Screen capture is unavailable"),
+    );
+    reopenApp.mockResolvedValue(undefined);
   });
 
   afterEach(() => vi.clearAllMocks());
 
-  it("fronts setup when the microphone was revoked", async () => {
+  it("preserves completed onboarding when macOS reports no microphone grant after an update", async () => {
     checkMicrophonePermission.mockResolvedValue(false);
     checkScreenRecordingPermission.mockResolvedValue(true);
     render(<App />);
 
     expect(
-      await screen.findByRole("dialog", { name: "Set up Savvy" }),
+      await screen.findByRole("heading", { name: "Prepare for your meeting" }),
     ).toBeVisible();
-    expect(screen.getByText(/needs its permissions back/)).toBeVisible();
+    expect(
+      screen.queryByRole("dialog", { name: "Set up Savvy" }),
+    ).not.toBeInTheDocument();
+    expect(checkMicrophonePermission).not.toHaveBeenCalled();
   });
 
   it("does not wall off the app over the optional screen recording permission", async () => {

--- a/src/Onboarding.tsx
+++ b/src/Onboarding.tsx
@@ -3,6 +3,8 @@ import { Check, FileText, Mic, MonitorPlay, X } from "lucide-react";
 import {
   getAppStatus,
   getTranscriptionKeyStatus,
+  reopenApp,
+  probeSystemAudioPermission,
   setTranscriptionApiKey,
 } from "./lib/api";
 import type { TranscriptionKeyStatus } from "./types";
@@ -32,13 +34,10 @@ async function macosPermissions() {
 
 type PermissionReading = { macos: boolean; mic: boolean; capture: boolean };
 
-/**
- * Reads the current permission state. Returns rather than sets, so callers own the
- * state update — a reader that set state itself would be a synchronous setState
- * inside an effect. A failed read returns null. Guessing "denied" would show the
- * user buttons that cannot work, with nothing explaining why.
- */
-async function readPermissions(): Promise<PermissionReading | null> {
+/** Returns null when permission status cannot be read. */
+async function readPermissions(
+  probeCapture = false,
+): Promise<PermissionReading | null> {
   try {
     const status = await getAppStatus();
     if (status.platform !== "macos") {
@@ -52,26 +51,22 @@ async function readPermissions(): Promise<PermissionReading | null> {
       checkMicrophonePermission(),
       checkScreenRecordingPermission(),
     ]);
+    if (probeCapture && !capture) {
+      try {
+        await probeSystemAudioPermission();
+        return { macos: true, mic, capture: true };
+      } catch {
+        // A failed capture probe must not erase the microphone result.
+      }
+    }
     return { macos: true, mic, capture };
   } catch {
     return null;
   }
 }
 
-/**
- * First-run setup.
- *
- * `returningUser` restricts the flow to the permission step: someone who already
- * finished onboarding but has since revoked a permission needs to repair it, not to
- * be onboarded again.
- */
-export default function Onboarding({
-  returningUser,
-  onComplete,
-}: {
-  returningUser: boolean;
-  onComplete: () => void;
-}) {
+/** First-run setup. Permission repair for existing installs happens at meeting start. */
+export default function Onboarding({ onComplete }: { onComplete: () => void }) {
   const [step, setStep] = useState<Step>("permissions");
   const [isMacos, setIsMacos] = useState(false);
   const [microphone, setMicrophone] = useState<PermissionStatus>("checking");
@@ -105,7 +100,7 @@ export default function Onboarding({
     setError(null);
     setMicrophone("checking");
     setScreen("checking");
-    if (!applyPermissions(await readPermissions())) reportCheckFailure();
+    if (!applyPermissions(await readPermissions(true))) reportCheckFailure();
   }, [applyPermissions, reportCheckFailure]);
 
   useEffect(() => {
@@ -116,8 +111,7 @@ export default function Onboarding({
 
   const settled = microphone === "granted" && screen === "granted";
 
-  // The user grants permissions in System Settings, outside this window, so the
-  // answer arrives whenever they come back, not within any fixed wait. Watch for it.
+  // Watch for permission changes made in System Settings while setup stays open.
   useEffect(() => {
     if (step !== "permissions" || !isMacos || settled) return;
     let failures = 0;
@@ -151,11 +145,10 @@ export default function Onboarding({
   }, [isMacos, settled, step]);
 
   useEffect(() => {
-    if (returningUser) return;
     void getTranscriptionKeyStatus()
       .then(setKeyStatus)
       .catch(() => undefined);
-  }, [returningUser]);
+  }, []);
 
   async function grantMicrophone() {
     setError(null);
@@ -163,7 +156,7 @@ export default function Onboarding({
     try {
       const { requestMicrophonePermission } = await macosPermissions();
       await requestMicrophonePermission();
-      // The system dialog has closed; show the answer now instead of on the next poll.
+      // The request returns before the dialog is answered; polling picks up a later grant.
       if ((await readPermissions())?.mic) setMicrophone("granted");
     } catch {
       setMicrophone("needed");
@@ -177,7 +170,7 @@ export default function Onboarding({
     try {
       const { requestScreenRecordingPermission } = await macosPermissions();
       await requestScreenRecordingPermission();
-      if ((await readPermissions())?.capture) setScreen("granted");
+      if ((await readPermissions(true))?.capture) setScreen("granted");
     } catch {
       setScreen("needed");
       setError("Savvy could not request screen recording access. Try again.");
@@ -198,17 +191,23 @@ export default function Onboarding({
     }
   }
 
+  async function reopen() {
+    setBusy(true);
+    setError(null);
+    try {
+      await reopenApp();
+    } catch (reason) {
+      setError(String(reason));
+    } finally {
+      setBusy(false);
+    }
+  }
+
   const hasAnyKey = keyStatus.deepgram || keyStatus.assemblyAi;
 
   if (step === "permissions") {
     return (
-      <OnboardingShell
-        subtitle={
-          returningUser
-            ? "Savvy needs its permissions back before the next meeting."
-            : "To get started, let Savvy hear the meeting."
-        }
-      >
+      <OnboardingShell subtitle="To get started, let Savvy hear the meeting.">
         <PermissionRow
           icon={Mic}
           title="Microphone"
@@ -238,6 +237,19 @@ export default function Onboarding({
             reopen Savvy.
           </p>
         )}
+        {(microphone === "waiting" || screen === "waiting") && (
+          <p className="onboarding-note">
+            Already allowed in System Settings? macOS may need a fresh launch to
+            recognize the change.
+            <button
+              className="button secondary"
+              disabled={busy}
+              onClick={() => void reopen()}
+            >
+              Reopen Savvy
+            </button>
+          </p>
+        )}
         <ErrorNotice message={error} onDismiss={() => setError(null)} />
         <div className="onboarding-actions">
           <button
@@ -251,8 +263,7 @@ export default function Onboarding({
             disabled={microphone !== "granted"}
             onClick={() => {
               setError(null);
-              if (returningUser) onComplete();
-              else setStep("transcription");
+              setStep("transcription");
             }}
           >
             Continue

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,3 +1,4 @@
+import { version } from "../../package.json";
 import { invoke } from "@tauri-apps/api/core";
 import { open } from "@tauri-apps/plugin-dialog";
 import { revealItemInDir } from "@tauri-apps/plugin-opener";
@@ -210,7 +211,7 @@ const browserSettings: AppSettings = {
 export async function getAppStatus(): Promise<AppStatus> {
   if (!window.__TAURI_INTERNALS__) {
     return {
-      version: "0.1.0",
+      version,
       platform: "browser",
     };
   }
@@ -687,4 +688,12 @@ export async function stopMeeting(sessionId: string): Promise<MeetingSession> {
     };
   }
   return invoke<MeetingSession>("stop_meeting", { sessionId });
+}
+
+export async function reopenApp(): Promise<void> {
+  if (window.__TAURI_INTERNALS__) await invoke("reopen_app");
+}
+
+export async function probeSystemAudioPermission(): Promise<void> {
+  if (window.__TAURI_INTERNALS__) await invoke("probe_system_audio_permission");
 }


### PR DESCRIPTION
Updating could send a user who had completed setup back into onboarding after a single false microphone-permission reading. Keep completed setup, check access when recording starts, and reopen macOS updates through Launch Services after the old process exits.

This prepares patch **0.1.2**. It does not create a tag or release, or change signing identities.

## Changes

- Recover valid settings when an unrelated field has an invalid type. Add an explicit ScreenCaptureKit recheck and a Reopen Savvy recovery action.
- Reject updates and reopening during meetings, report update failures, and start update checks after initialization. Run capture, settings, and quit work off the event loop.
- Adapt shipped Handy improvements for native theme and settings synchronization, idle overlay rendering, bounded microphone polling, disconnected microphone fallback, and capture-error reporting. No dependencies added.
- Review comments and Markdown, correct platform and local-updater documentation, and read the browser preview version from package.json.

The [upstream review and implementation plan](https://github.com/jamalavedra/savvy/blob/fix/handy-reliability-0.1.2/plan/upgrade-handy-improvements-1.md) accounts for all 116 PR entries in Handy v0.9.0 through v0.9.6, including the changes already covered or deferred. The [permission investigation](https://github.com/jamalavedra/savvy/blob/fix/handy-reliability-0.1.2/docs/update-permissions-investigation.md) separates the confirmed onboarding trigger from the inferred macOS relaunch issue. Published Savvy v0.1.0 and v0.1.1 bundles passed strict signature verification with matching designated requirements. Savvy does not request Accessibility permission.

## Validation

- `pnpm verify`: 44 frontend tests and 76 Rust tests passed, plus formatting, TypeScript, ESLint, production build, and Clippy. Two existing external-provider tests remain ignored.
- `cargo fmt --all --check`, `git diff --check`, and `cargo deny check` passed.
- Regression coverage includes completed setup with a false permission reading, malformed settings, explicit permission recovery, relaunch ordering and literal arguments, microphone fallback, and overlay polling/lifecycle.

A signed in-app update cycle, physical microphone disconnect/reconnect, native theme rendering, and quitting during settings work still need installed-app verification. The incident's TCC state was not reproduced. The first upgrade into this fix still uses the old installed updater to relaunch, so a manual reopen may be needed once.
