### PR TITLE
Simplify Savvy website; add privacy, analytics and Cloudflare hosting

### DIFF
--- a/.github/workflows/www.yml
+++ b/.github/workflows/www.yml
@@ -1,0 +1,36 @@
+name: Website
+
+on:
+  pull_request:
+    paths: ["www/**", ".github/workflows/www.yml"]
+  push:
+    branches: [main]
+    paths: ["www/**", ".github/workflows/www.yml"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  website:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: www
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+        with:
+          package_json_file: www/package.json
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: www/pnpm-lock.yaml
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm lint
+      - run: pnpm build
+      - run: node --test smoke.test.mjs
+      - run: pnpm deploy:check

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,9 +1,10 @@
-import { defineConfig } from "vitest/config";
+import { configDefaults, defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
 
 export default defineConfig({
   plugins: [react()],
   test: {
+    exclude: [...configDefaults.exclude, "www/**"],
     environment: "jsdom",
     globals: true,
     setupFiles: ["./src/test/setup.ts"],

--- a/www/.gitignore
+++ b/www/.gitignore
@@ -4,3 +4,4 @@
 *.tsbuildinfo
 next-env.d.ts
 .DS_Store
+/.wrangler/

--- a/www/README.md
+++ b/www/README.md
@@ -22,7 +22,7 @@ The CLI version is pinned in the scripts and downloaded by pnpm when needed.
 ```sh
 pnpm dlx wrangler@4.127.1 login
 pnpm dlx wrangler@4.127.1 whoami
-CLOUDFLARE_ACCOUNT_ID=<intended-account-id> pnpm deploy
+CLOUDFLARE_ACCOUNT_ID=<intended-account-id> pnpm run deploy
 ```
 
 Sign into the Cloudflare account that owns `savvycopilot.com`. Verify the account

--- a/www/README.md
+++ b/www/README.md
@@ -39,3 +39,10 @@ CI validates the site but does not deploy it.
 
 Mascot images come from `src/assets/mascot-states` in the desktop app and the icon
 from `src-tauri/icons`. Video attribution is in `public/videos/SOURCE.md`.
+
+## Privacy and analytics
+
+The privacy notice is at `/privacy/`. Optional Umami analytics loads only after an
+explicit choice in Privacy preferences. A choice lasts up to one year in this
+browser; withdrawing it reloads the page to stop the tracker. Run
+`node --test smoke.test.mjs` after building to check the export and consent records.

--- a/www/README.md
+++ b/www/README.md
@@ -1,36 +1,46 @@
-# Savvy landing site
+# Savvy website
 
-The marketing site for [Savvy](https://github.com/jamalavedra/savvy), a local-first macOS
-meeting assistant. The app itself lives in the repository root; this folder only contains
-the public website.
+Static Next.js site for Savvy. The desktop app lives in the repository root.
+The FAQ uses native HTML; entrance animations use CSS.
 
-## Stack
+## Development
 
-- Next.js 16 (App Router)
-- Tailwind CSS 4
-- framer-motion for motion, Radix UI accordion for the FAQ
-- Biome for linting and formatting
-
-## Commands
-
-```bash
-pnpm install
-pnpm dev        # http://localhost:3012
-pnpm build      # static export into out/
-pnpm lint       # biome check
-pnpm typecheck  # tsc --noEmit
+```sh
+pnpm install --frozen-lockfile
+pnpm dev        # localhost:3012
+pnpm lint
+pnpm build      # static files in out/; includes TypeScript checking
+pnpm start      # serve the export locally with Wrangler
+pnpm deploy:check
 ```
 
-## Deploying
+## Cloudflare deployment
 
-`pnpm build` writes a static export to `out/`, which any static host can serve — GitHub
-Pages, Cloudflare Pages, S3, Netlify. There is no server runtime and no API routes.
+Wrangler serves `out/` as Worker static assets, with no application server.
+The CLI version is pinned in the scripts and downloaded by pnpm when needed.
 
-Set `SITE_URL` in `src/lib/constants.ts` to the real domain before deploying. It is used
-for canonical URLs, Open Graph tags, `robots.txt` and the sitemap.
+```sh
+pnpm dlx wrangler@4.127.1 login
+pnpm dlx wrangler@4.127.1 whoami
+CLOUDFLARE_ACCOUNT_ID=<intended-account-id> pnpm deploy
+```
+
+Sign into the Cloudflare account that owns `savvycopilot.com`. Verify the account
+before deploying, especially if Wrangler was previously used with another account.
+Never commit credentials. The configuration deliberately has no account ID or route
+until the owning account and active DNS zone have been verified.
+
+After verification, add a custom-domain route to `wrangler.jsonc`:
+
+```json
+"routes": [{ "pattern": "savvycopilot.com", "custom_domain": true }]
+```
+
+`SITE_URL` in `src/lib/constants.ts` controls canonical URLs, social metadata,
+robots.txt and the sitemap. It is set to `https://savvycopilot.com`.
+CI validates the site but does not deploy it.
 
 ## Assets
 
-Images in `public/images` are copied from the app: the mascot states come from
-`src/assets/mascot-states` and the icon from `src-tauri/icons`. Update them there first,
-then copy the new files across.
+Mascot images come from `src/assets/mascot-states` in the desktop app and the icon
+from `src-tauri/icons`. Video attribution is in `public/videos/SOURCE.md`.

--- a/www/README.md
+++ b/www/README.md
@@ -27,14 +27,9 @@ CLOUDFLARE_ACCOUNT_ID=<intended-account-id> pnpm deploy
 
 Sign into the Cloudflare account that owns `savvycopilot.com`. Verify the account
 before deploying, especially if Wrangler was previously used with another account.
-Never commit credentials. The configuration deliberately has no account ID or route
-until the owning account and active DNS zone have been verified.
-
-After verification, add a custom-domain route to `wrangler.jsonc`:
-
-```json
-"routes": [{ "pattern": "savvycopilot.com", "custom_domain": true }]
-```
+Never commit credentials. The custom-domain route is configured for
+`savvycopilot.com`. Pass the verified account ID when deploying; no account ID is
+stored in the repository.
 
 `SITE_URL` in `src/lib/constants.ts` controls canonical URLs, social metadata,
 robots.txt and the sitemap. It is set to `https://savvycopilot.com`.

--- a/www/package.json
+++ b/www/package.json
@@ -6,14 +6,14 @@
   "scripts": {
     "dev": "next dev -p 3012",
     "build": "next build",
-    "start": "npx serve out",
+    "start": "pnpm dlx wrangler@4.127.1 dev",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "deploy": "pnpm build && pnpm dlx wrangler@4.127.1 deploy",
+    "deploy:check": "pnpm dlx wrangler@4.127.1 deploy --dry-run"
   },
   "dependencies": {
-    "@radix-ui/react-accordion": "1.2.20",
-    "framer-motion": "13.2.0",
     "next": "16.3.4",
     "react": "19.2.8",
     "react-dom": "19.2.8"

--- a/www/pnpm-lock.yaml
+++ b/www/pnpm-lock.yaml
@@ -8,12 +8,6 @@ importers:
 
   .:
     dependencies:
-      '@radix-ui/react-accordion':
-        specifier: 1.2.20
-        version: 1.2.20(@types/react-dom@19.2.7(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      framer-motion:
-        specifier: 13.2.0
-        version: 13.2.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       next:
         specifier: 16.3.4
         version: 16.3.4(@types/node@26.4.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)

--- a/www/smoke.test.mjs
+++ b/www/smoke.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { access, readFile } from "node:fs/promises";
 import { test } from "node:test";
+import { CONSENT_YEAR, readConsent } from "./src/lib/consent.ts";
 
 test("static export has metadata, FAQ answers and referenced assets", async () => {
   const html = await readFile("out/index.html", "utf8");
@@ -14,4 +15,37 @@ test("static export has metadata, FAQ answers and referenced assets", async () =
     assert.match(await readFile(`out/${file}`, "utf8"), /https:\/\/savvycopilot\.com/);
   }
   await access("out/404.html");
+});
+
+test("analytics requires a valid unexpired explicit choice", () => {
+  const now = 1000;
+  for (const raw of [
+    null,
+    "bad json",
+    "null",
+    "true",
+    "{}",
+    '{"allowed":"true","expires":2000}',
+    '{"allowed":true,"expires":1000}',
+    JSON.stringify({ allowed: true, expires: now + CONSENT_YEAR + 1 }),
+  ]) {
+    assert.equal(readConsent(raw, now), null);
+  }
+  for (const allowed of [true, false]) {
+    assert.deepEqual(readConsent(JSON.stringify({ allowed, expires: 2000 }), now), {
+      allowed,
+      expires: 2000,
+    });
+  }
+});
+
+test("privacy notice is linked and analytics is absent from initial HTML", async () => {
+  const home = await readFile("out/index.html", "utf8");
+  const privacy = await readFile("out/privacy/index.html", "utf8");
+  assert.match(home, /href="\/privacy\/"/);
+  assert.doesNotMatch(home, /<script[^>]+src="https:\/\/analytics\.jamalavedra\.com/);
+  assert.match(privacy, /rel="canonical" href="https:\/\/savvycopilot\.com\/privacy\/"/);
+  assert.match(privacy, /Alamas Labs, Inc\./);
+  assert.match(privacy, /mailto:hello@bonofici\.com/);
+  assert.doesNotMatch(privacy, /Draft for review|\[Confirm|\[public privacy/);
 });

--- a/www/smoke.test.mjs
+++ b/www/smoke.test.mjs
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import { access, readFile } from "node:fs/promises";
+import { test } from "node:test";
+
+test("static export has metadata, FAQ answers and referenced assets", async () => {
+  const html = await readFile("out/index.html", "utf8");
+  assert.match(html, /rel="canonical" href="https:\/\/savvycopilot\.com\/"/);
+  assert.equal([...html.matchAll(/<details[ >]/g)].length, 8);
+  assert.match(html, /<summary[^>]*>Where does my data go\?/);
+  for (const [, asset] of html.matchAll(/(?:src|poster)="(\/[^"?]+)"/g)) {
+    await access(`out${asset}`);
+  }
+  for (const file of ["robots.txt", "sitemap.xml"]) {
+    assert.match(await readFile(`out/${file}`, "utf8"), /https:\/\/savvycopilot\.com/);
+  }
+  await access("out/404.html");
+});

--- a/www/smoke.test.mjs
+++ b/www/smoke.test.mjs
@@ -46,6 +46,6 @@ test("privacy notice is linked and analytics is absent from initial HTML", async
   assert.doesNotMatch(home, /<script[^>]+src="https:\/\/analytics\.jamalavedra\.com/);
   assert.match(privacy, /rel="canonical" href="https:\/\/savvycopilot\.com\/privacy\/"/);
   assert.match(privacy, /Alamas Labs, Inc\./);
-  assert.match(privacy, /mailto:hello@bonofici\.com/);
+  assert.match(privacy, /mailto:hello@savvycopilot\.com/);
   assert.doesNotMatch(privacy, /Draft for review|\[Confirm|\[public privacy/);
 });

--- a/www/src/app/globals.css
+++ b/www/src/app/globals.css
@@ -40,11 +40,7 @@
   }
 }
 
-/* ── Content column ──
-   The money.x.com geometry: below xl the column is centred on the viewport;
-   at xl+ the fixed 208px rail claims the left lane and the column centres in
-   what is left, capped at 1232px. Must be applied to a direct child of a
-   full-width element — the margin maths resolves `100%` against its parent. */
+/* Leave room for the fixed navigation rail on wide screens. */
 @utility page-column {
   margin-inline: auto;
   max-width: 64rem;
@@ -84,7 +80,7 @@ body {
   transform: rotate(-1deg);
 }
 
-/* ── Slow circular drift for band pods (money.x.com style) ──
+/* Slow circular drift for decorative cards.
    rotate/counter-rotate keeps the card upright while it circles its anchor. */
 @keyframes pod-orbit {
   from {
@@ -391,35 +387,19 @@ body {
   }
 }
 
-/* ── Accordion animations (Radix) ── */
-@keyframes slideDown {
+@keyframes fade-in-up {
   from {
-    height: 0;
-    opacity: 0;
+    transform: translateY(16px);
   }
   to {
-    height: var(--radix-accordion-content-height);
-    opacity: 1;
+    transform: translateY(0);
   }
 }
 
-@keyframes slideUp {
-  from {
-    height: var(--radix-accordion-content-height);
-    opacity: 1;
+@media (prefers-reduced-motion: no-preference) {
+  .fade-in-up {
+    animation: fade-in-up 0.6s var(--ease-smooth) backwards;
   }
-  to {
-    height: 0;
-    opacity: 0;
-  }
-}
-
-.accordion-content[data-state="open"] {
-  animation: slideDown 0.3s var(--ease-out-quart);
-}
-
-.accordion-content[data-state="closed"] {
-  animation: slideUp 0.3s var(--ease-out-quart);
 }
 
 .focus-ring:focus-visible {
@@ -442,9 +422,7 @@ body {
   .press,
   .playhead,
   .row-expire,
-  .ring-sweep,
-  .accordion-content[data-state="open"],
-  .accordion-content[data-state="closed"] {
+  .ring-sweep {
     animation: none;
   }
   .file-drop,

--- a/www/src/app/layout.tsx
+++ b/www/src/app/layout.tsx
@@ -3,9 +3,9 @@ import { SITE_URL } from "@/lib/constants";
 import { inter, jetbrainsMono } from "@/lib/fonts";
 import "./globals.css";
 
-const TITLE = "Savvy — Source-grounded live guidance for meetings, on your Mac";
+const TITLE = "Savvy | AI guidance from your documents, on your Mac";
 const DESCRIPTION =
-  "Savvy reads your documents before the meeting, then listens alongside you and whispers what to say, what to avoid, and which file says so. Local-first macOS meeting assistant, open source.";
+  "Prepare from your documents and get suggestions during conversations. Savvy is an open-source Mac app that shows guidance with supporting sources.";
 
 export const metadata: Metadata = {
   title: TITLE,

--- a/www/src/app/layout.tsx
+++ b/www/src/app/layout.tsx
@@ -38,6 +38,14 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: Readonly<{ children: React.ReactNode }>) {
   return (
     <html lang="en">
+      <head>
+        <script
+          defer
+          src="https://analytics.jamalavedra.com/script.js"
+          data-website-id="8a7ddcdb-2cee-4719-a8f2-9c18aa8239e7"
+          data-domains="savvycopilot.com"
+        />
+      </head>
       <body className={`${inter.variable} ${jetbrainsMono.variable}`}>{children}</body>
     </html>
   );

--- a/www/src/app/layout.tsx
+++ b/www/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { Analytics } from "@/components/Analytics";
 import { SITE_URL } from "@/lib/constants";
 import { inter, jetbrainsMono } from "@/lib/fonts";
 import "./globals.css";
@@ -38,15 +39,10 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: Readonly<{ children: React.ReactNode }>) {
   return (
     <html lang="en">
-      <head>
-        <script
-          defer
-          src="https://analytics.jamalavedra.com/script.js"
-          data-website-id="8a7ddcdb-2cee-4719-a8f2-9c18aa8239e7"
-          data-domains="savvycopilot.com"
-        />
-      </head>
-      <body className={`${inter.variable} ${jetbrainsMono.variable}`}>{children}</body>
+      <body className={`${inter.variable} ${jetbrainsMono.variable}`}>
+        {children}
+        <Analytics />
+      </body>
     </html>
   );
 }

--- a/www/src/app/opengraph-image.tsx
+++ b/www/src/app/opengraph-image.tsx
@@ -3,7 +3,7 @@ import path from "node:path";
 import { ImageResponse } from "next/og";
 
 export const dynamic = "force-static";
-export const alt = "Savvy — source-grounded live guidance for meetings, on your Mac.";
+export const alt = "Savvy: AI guidance from your documents, on your Mac.";
 export const size = { width: 1200, height: 630 };
 export const contentType = "image/png";
 
@@ -38,7 +38,7 @@ export default function OpenGraphImage() {
         <div style={{ display: "flex", flexDirection: "column" }}>
           <div style={{ display: "flex", flexDirection: "column", color: "#0f0f0f" }}>
             <div style={{ fontSize: 70, fontWeight: 700, letterSpacing: "-0.035em" }}>
-              Hard question?
+              Your notes,
             </div>
             <div
               style={{
@@ -48,11 +48,11 @@ export default function OpenGraphImage() {
                 color: "#77736e",
               }}
             >
-              You already know.
+              when you need them.
             </div>
           </div>
           <div style={{ display: "flex", marginTop: 28, fontSize: 30, color: "#77736e" }}>
-            Source-grounded live guidance for meetings, on your Mac.
+            AI guidance from your documents, on your Mac.
           </div>
         </div>
         <div style={{ display: "flex", fontSize: 44, fontWeight: 700, color: "#f9a3ab" }}>

--- a/www/src/app/privacy/page.tsx
+++ b/www/src/app/privacy/page.tsx
@@ -24,7 +24,7 @@ export default function PrivacyPolicy() {
       <p>
         Alamas Labs, Inc., a Delaware corporation in the United States, operates savvycopilot.com
         and is responsible for the website processing described here. Contact{" "}
-        <a href="mailto:hello@bonofici.com">hello@bonofici.com</a> with privacy questions or
+        <a href="mailto:hello@savvycopilot.com">hello@savvycopilot.com</a> with privacy questions or
         requests.
       </p>
       <p>
@@ -135,9 +135,10 @@ export default function PrivacyPolicy() {
         without affecting earlier lawful processing.
       </p>
       <p>
-        Contact <a href="mailto:hello@bonofici.com">hello@bonofici.com</a> to make a request. We may
-        need enough information to verify and locate the relevant records. We cannot access or erase
-        files that remain only on your Mac or data held in your own provider accounts.
+        Contact <a href="mailto:hello@savvycopilot.com">hello@savvycopilot.com</a> to make a
+        request. We may need enough information to verify and locate the relevant records. We cannot
+        access or erase files that remain only on your Mac or data held in your own provider
+        accounts.
       </p>
       <p>
         You can complain to your local data protection authority. In Spain, this is the

--- a/www/src/app/privacy/page.tsx
+++ b/www/src/app/privacy/page.tsx
@@ -1,0 +1,154 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Privacy policy | Savvy",
+  description: "How the Savvy website and desktop app handle information.",
+  alternates: { canonical: "/privacy/" },
+  openGraph: {
+    title: "Privacy policy | Savvy",
+    description: "How the Savvy website and desktop app handle information.",
+    url: "/privacy/",
+  },
+};
+
+export default function PrivacyPolicy() {
+  return (
+    <main className="mx-auto max-w-3xl px-6 py-12 text-sm leading-relaxed sm:py-20 [&_h2]:mt-10 [&_h2]:mb-3 [&_h2]:text-xl [&_h2]:font-medium [&_p]:mt-3 [&_a]:underline [&_a]:underline-offset-4">
+      <a href="/" className="focus-ring">
+        Back to Savvy
+      </a>
+      <h1 className="mt-8 text-4xl font-medium tracking-tight">Privacy policy</h1>
+      <p className="text-muted">Last updated: 6 September 2026</p>
+
+      <h2>Who is responsible</h2>
+      <p>
+        Alamas Labs, Inc., a Delaware corporation in the United States, operates savvycopilot.com
+        and is responsible for the website processing described here. Contact{" "}
+        <a href="mailto:hello@bonofici.com">hello@bonofici.com</a> with privacy questions or
+        requests.
+      </p>
+      <p>
+        This notice covers the public website and explains the current open-source desktop app,
+        where you connect your own providers. It does not describe a future managed subscription
+        service.
+      </p>
+
+      <h2>Website hosting and security</h2>
+      <p>
+        Cloudflare delivers this website and protects it from abuse. Requests include your IP
+        address, the requested URL, browser information, and connection details. Cloudflare
+        processes this information to serve pages, maintain reliability, and detect malicious
+        traffic. We rely on our legitimate interest in operating a secure, working website for this
+        processing.
+      </p>
+      <p>
+        Cloudflare operates internationally, so processing can take place outside your country,
+        including outside the European Economic Area. Its data processing terms describe the
+        safeguards that apply to international transfers, including standard contractual clauses.
+        See <a href="https://www.cloudflare.com/privacypolicy/">Cloudflare's privacy policy</a> and
+        its <a href="https://www.cloudflare.com/cloudflare-customer-dpa/">data processing terms</a>.
+      </p>
+
+      <h2>Website analytics</h2>
+      <p>
+        With your permission, we use our Umami installation at analytics.jamalavedra.com to
+        understand how people find and use this website. It records page visits, referring URLs,
+        visit times, browser and device information, language, and approximate location. Page URLs
+        can include query parameters. Please do not put private information in links to this site.
+      </p>
+      <p>
+        Umami's tracking script does not use cookies. Umami processes IP addresses and browser
+        information to derive location and generate session identifiers. Raw IP addresses are not
+        stored in Umami's analytics records, but generating session identifiers still involves
+        processing connection information. Hosting infrastructure can process connection data
+        separately.
+      </p>
+      <p>
+        This website does not supply names, email addresses, or account identifiers to Umami. The
+        installed snippet does not enable session replay or heatmaps. Website analytics does not
+        collect your desktop app's documents, meeting audio, or transcripts.
+      </p>
+      <p>
+        We rely on consent for optional analytics. It stays off until you choose Allow analytics.
+        Use the Privacy preferences control on any page to reject analytics or withdraw your
+        consent. Your choice applies to this browser and is stored locally for up to one year.
+        Clearing browser storage removes it. Withdrawing consent stops future collection; it does
+        not undo earlier lawful processing or automatically delete existing records.
+      </p>
+      <p>
+        We do not run advertising trackers or sell your personal information. Our self-hosted
+        analytics service and its hosting infrastructure process the visit data described above. We
+        operate from the United States and use infrastructure that may process data in other
+        countries. Where required for transfers from the EEA or UK, we use appropriate safeguards,
+        including standard contractual clauses. Contact us for information about those safeguards.
+      </p>
+
+      <h2>How long information is kept</h2>
+      <p>
+        We retain analytics while it remains useful for website reporting and improvement. Analytics
+        records have no fixed automatic expiry and remain until manually deleted. Our hosting
+        providers handle connection and security records according to their applicable service terms
+        and policies. The desktop app has a separate local retention rule, explained below.
+      </p>
+
+      <h2>Desktop app and your providers</h2>
+      <p>
+        The current desktop app reads source files from folders you choose and stores extracted
+        text, indexes, briefs, recordings, and transcripts on your Mac. It leaves the source files
+        unchanged. Local recordings and transcripts older than 30 days are removed when the app
+        starts. This startup cleanup does not delete copies held by providers or backups.
+      </p>
+      <p>
+        During transcription, audio is sent to the Deepgram or AssemblyAI account you configure. AI
+        tasks send selected document excerpts, briefs, and relevant conversation context to the
+        provider used by your signed-in Codex or Claude Code CLI. These services process information
+        under your account and their own terms. Review those terms and settings before using
+        confidential material or recording other people.
+      </p>
+      <p>
+        Transcription API keys are stored in macOS Keychain. The website's analytics service does
+        not receive these keys. Removing a client in the app removes its derived local data without
+        deleting the original source folder.
+      </p>
+
+      <h2>Contact and external links</h2>
+      <p>
+        If you contact us, we process the information you send to respond to your request. Our legal
+        basis is our legitimate interest in responding to enquiries, or compliance with a legal
+        obligation when handling data-protection requests. Correspondence is held in our business
+        mailbox. If an enquiry does not lead to an engagement, we retain it for up to 24 months
+        after the last contact. We keep client correspondence for the engagement and afterward as
+        needed to meet legal and accounting obligations.
+      </p>
+      <p>
+        Downloads, source code, and issue reports are hosted on GitHub. If you follow those links,
+        GitHub processes your visit under its own privacy notice. Issues in the public repository
+        are public, so do not include personal information, recordings, API keys, or confidential
+        documents in an issue.
+      </p>
+
+      <h2>Your rights</h2>
+      <p>
+        Depending on the law that applies, you can request access, correction, deletion,
+        restriction, or portability of personal data we hold about you. You can object to processing
+        based on legitimate interests. Where processing relies on consent, you can withdraw it
+        without affecting earlier lawful processing.
+      </p>
+      <p>
+        Contact <a href="mailto:hello@bonofici.com">hello@bonofici.com</a> to make a request. We may
+        need enough information to verify and locate the relevant records. We cannot access or erase
+        files that remain only on your Mac or data held in your own provider accounts.
+      </p>
+      <p>
+        You can complain to your local data protection authority. In Spain, this is the
+        <a href="https://www.aepd.es/"> Spanish Data Protection Agency</a>.
+      </p>
+
+      <h2>Changes to this notice</h2>
+      <p>
+        We will update this page when our processing changes and show the effective date here.
+        Material changes will be explained before the new processing begins.
+      </p>
+    </main>
+  );
+}

--- a/www/src/app/sitemap.ts
+++ b/www/src/app/sitemap.ts
@@ -11,5 +11,6 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: "weekly",
       priority: 1,
     },
+    { url: `${SITE_URL}/privacy/`, changeFrequency: "monthly", priority: 0.3 },
   ];
 }

--- a/www/src/components/Analytics.tsx
+++ b/www/src/components/Analytics.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { CONSENT_KEY as KEY, readConsent, CONSENT_YEAR as YEAR } from "@/lib/consent";
+
+export function Analytics() {
+  const [open, setOpen] = useState(false);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    let allowed = false;
+    let expires = 0;
+    try {
+      const saved = readConsent(localStorage.getItem(KEY));
+      allowed = saved?.allowed ?? false;
+      expires = saved?.expires ?? 0;
+    } catch {
+      // Unavailable storage or an invalid record leaves analytics off.
+    }
+    setOpen(!expires);
+    const reload = () => location.reload();
+    const onStorage = (event: StorageEvent) => {
+      if (event.key === KEY || event.key === null) reload();
+    };
+    window.addEventListener("storage", onStorage);
+    const timer = expires
+      ? window.setTimeout(reload, Math.min(expires - Date.now(), 2147483647))
+      : undefined;
+    let script: HTMLScriptElement | undefined;
+    if (allowed) {
+      script = document.createElement("script");
+      script.src = "https://analytics.jamalavedra.com/script.js";
+      script.dataset.websiteId = "8a7ddcdb-2cee-4719-a8f2-9c18aa8239e7";
+      script.dataset.domains = "savvycopilot.com";
+      script.defer = true;
+      document.head.append(script);
+    }
+    return () => {
+      script?.remove();
+      window.clearTimeout(timer);
+      window.removeEventListener("storage", onStorage);
+    };
+  }, []);
+
+  function choose(allowed: boolean) {
+    try {
+      localStorage.setItem(KEY, JSON.stringify({ allowed, expires: Date.now() + YEAR }));
+      // Reload also removes the tracker's listeners when consent is withdrawn.
+      location.reload();
+    } catch {
+      setError(
+        "Your browser could not save this choice. You can clear this site's storage in your browser settings.",
+      );
+    }
+  }
+
+  return (
+    <aside
+      aria-label="Privacy preferences"
+      className="fixed bottom-4 left-4 right-4 z-50 sm:right-auto sm:max-w-md"
+    >
+      {open ? (
+        <div className="rounded-xl border border-border bg-surface p-5 shadow-lg">
+          <h2 className="font-medium">Optional website analytics</h2>
+          <p className="mt-2 text-sm text-muted">
+            Allow Umami to count visits and show us how this website is used? Analytics stays off
+            until you allow it. You can change your choice here at any time.
+          </p>
+          <a href="/privacy/" className="focus-ring mt-2 inline-block text-sm underline">
+            Privacy policy
+          </a>
+          <div className="mt-4 flex flex-wrap gap-3">
+            <button
+              type="button"
+              onClick={() => choose(false)}
+              className="focus-ring rounded-full border border-border px-4 py-2 text-sm"
+            >
+              Reject analytics
+            </button>
+            <button
+              type="button"
+              onClick={() => choose(true)}
+              className="focus-ring rounded-full border border-border px-4 py-2 text-sm"
+            >
+              Allow analytics
+            </button>
+            <button
+              type="button"
+              onClick={() => setOpen(false)}
+              className="focus-ring px-2 text-sm underline"
+            >
+              Close
+            </button>
+          </div>
+          {error && (
+            <p role="alert" className="mt-3 text-sm">
+              {error}
+            </p>
+          )}
+        </div>
+      ) : (
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          className="focus-ring rounded-full border border-border bg-surface px-4 py-2 text-xs shadow-sm"
+        >
+          Privacy preferences
+        </button>
+      )}
+    </aside>
+  );
+}

--- a/www/src/components/animations/FadeInUp.tsx
+++ b/www/src/components/animations/FadeInUp.tsx
@@ -1,40 +1,17 @@
-"use client";
-
-import { motion } from "framer-motion";
 import type { ReactNode } from "react";
-
-// Stable component identities: creating these per render (motion.create(as))
-// gives a new component each time, so any parent re-render remounts the
-// subtree and replays the entrance animation.
-const MOTION = {
-  div: motion.div,
-  li: motion.li,
-  section: motion.section,
-} as const;
 
 export function FadeInUp({
   children,
   delay = 0,
-  className,
-  as = "div",
+  className = "",
 }: {
   children: ReactNode;
   delay?: number;
   className?: string;
-  as?: keyof typeof MOTION;
 }) {
-  const Component = MOTION[as];
-
   return (
-    <Component
-      // y-only: content stays visible even if the animation never runs.
-      initial={{ y: 16 }}
-      whileInView={{ y: 0 }}
-      viewport={{ once: true, margin: "-10%" }}
-      transition={{ duration: 0.6, ease: [0.25, 0.1, 0.35, 1], delay }}
-      className={className}
-    >
+    <div className={`fade-in-up ${className}`} style={{ animationDelay: `${delay}s` }}>
       {children}
-    </Component>
+    </div>
   );
 }

--- a/www/src/components/layout/Footer.tsx
+++ b/www/src/components/layout/Footer.tsx
@@ -21,6 +21,7 @@ const COLUMNS: { heading: string; links: FooterLink[] }[] = [
   {
     heading: "Support",
     links: [
+      { label: "Privacy policy", href: "/privacy/" },
       { label: "Report an issue", href: LINKS.issues, external: true },
       { label: "README", href: LINKS.readme, external: true },
     ],

--- a/www/src/components/layout/Footer.tsx
+++ b/www/src/components/layout/Footer.tsx
@@ -63,7 +63,6 @@ export function Footer() {
         </p>
       </div>
 
-      {/* Outlined wordmark bleeding to the viewport edges, money.x.com style. */}
       <div aria-hidden className="select-none overflow-hidden">
         <p
           className="whitespace-nowrap text-center font-bold uppercase leading-[0.78] tracking-tight text-transparent"

--- a/www/src/components/layout/Rail.tsx
+++ b/www/src/components/layout/Rail.tsx
@@ -4,9 +4,6 @@ import { Wordmark } from "@/components/layout/Wordmark";
 import { DownloadCTA } from "@/components/ui/DownloadCTA";
 import { NAV, REPO_URL } from "@/lib/constants";
 
-// money.x.com-style fixed left rail. Only shown on xl+, where the page-column
-// utility reserves a 208px lane on the left for it; below that the regular
-// top Header takes over.
 export function Rail({ active = "/" }: { active?: string }) {
   return (
     <>

--- a/www/src/components/overlay/pieces.tsx
+++ b/www/src/components/overlay/pieces.tsx
@@ -119,7 +119,7 @@ export function StatusLine({
 }) {
   const thinking = status !== "listening" && status !== "muted";
   return (
-    <div className="overlay-status" role="status">
+    <div className="overlay-status">
       <span className="overlay-status-copy">
         <Mascot state={mascotFor(status)} />
         <span className="overlay-status-label">{children ?? STATUS_LABEL[status]}</span>

--- a/www/src/components/sections/Everything.tsx
+++ b/www/src/components/sections/Everything.tsx
@@ -11,8 +11,6 @@ import {
 } from "@/components/sections/vignettes";
 
 // Numbered bento — the "One app / Everything money can do" section from
-// money.x.com: square media card with the text column BESIDE it (number top,
-// title+body bottom). Vignettes are icon-and-motion loops, not prose.
 
 type Item = { n: number; title: string; body: string; vignette: ReactNode };
 
@@ -41,7 +39,7 @@ const ITEMS: Item[] = [
   {
     n: 1,
     title: "Point it at a folder",
-    body: "PDF, DOCX, PPTX, XLSX, CSV, Markdown, EPUB. Indexed read-only, never copied.",
+    body: "PDF, DOCX, PPTX, XLSX, CSV, Markdown, EPUB. Source files stay in place; extracted text is indexed locally.",
     vignette: <FolderVignette />,
   },
   {
@@ -53,7 +51,7 @@ const ITEMS: Item[] = [
   {
     n: 3,
     title: "Hears both sides",
-    body: "Microphone and system audio, labelled separately, in whatever language the meeting is in. No bot joins the call.",
+    body: "Microphone and system audio, labelled separately, with selectable transcription languages. No bot joins the call.",
     vignette: <ChannelsVignette />,
   },
   {
@@ -65,13 +63,13 @@ const ITEMS: Item[] = [
   {
     n: 5,
     title: "Advice on demand",
-    body: "Press Advice, or the shortcut, for a read on the room from the brief and the last minute of talk.",
+    body: "Press Advice, or the shortcut, for guidance based on your brief and recent conversation.",
     vignette: <AdviceVignette />,
   },
   {
     n: 6,
-    title: "Meetings stay on this Mac",
-    body: "Recordings and transcripts are saved locally and deleted after 30 days.",
+    title: "Local meeting history",
+    body: "Recordings and transcripts are saved locally. Startup cleanup removes those older than 30 days.",
     vignette: <HistoryVignette />,
   },
 ];

--- a/www/src/components/sections/FAQ.tsx
+++ b/www/src/components/sections/FAQ.tsx
@@ -1,62 +1,35 @@
-"use client";
-
-import * as Accordion from "@radix-ui/react-accordion";
 import { FadeInUp } from "@/components/animations/FadeInUp";
 import { TwoLineHeading } from "@/components/sections/primitives";
 import { faqItems } from "@/content/faq";
 import { LINKS } from "@/lib/constants";
-
-// The open item is a filled block with a minus; closed items are plain rows
-// with a plus. The vertical bar collapses instead of rotating, so the two
-// states read as the same mark.
-function PlusMinus() {
-  return (
-    <span aria-hidden className="relative block h-3 w-3 shrink-0">
-      <span className="absolute left-0 top-1/2 h-[1.5px] w-full -translate-y-1/2 bg-current" />
-      <span className="absolute left-1/2 top-0 h-full w-[1.5px] -translate-x-1/2 bg-current transition-transform duration-300 group-data-[state=open]:scale-y-0" />
-    </span>
-  );
-}
 
 export function FAQ() {
   return (
     <section id="faq" className="py-20 lg:py-28">
       <div className="page-column grid gap-10 lg:grid-cols-[1fr_1.4fr]">
         <FadeInUp>
-          <TwoLineHeading
-            line1="Your questions, answered"
-            line2="Before you point it at anything"
-          />
+          <TwoLineHeading line1="Questions about Savvy" />
           <a
             href={LINKS.readme}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="mt-6 inline-flex items-center rounded-full bg-foreground px-5 py-2.5 text-sm font-semibold text-background transition-opacity hover:opacity-80"
+            className="focus-ring mt-6 inline-flex rounded-full bg-foreground px-5 py-2.5 text-sm font-semibold text-background"
           >
             Read the README
           </a>
         </FadeInUp>
-
         <FadeInUp delay={0.1}>
-          <Accordion.Root type="single" collapsible defaultValue="q-0">
-            {faqItems.map((item, i) => (
-              <Accordion.Item
-                key={item.question}
-                value={`q-${i}`}
-                className="group px-6 py-1.5 transition-colors data-[state=open]:bg-background-alt data-[state=open]:py-3"
-              >
-                <Accordion.Header>
-                  <Accordion.Trigger className="focus-ring flex w-full items-center justify-between gap-4 py-3.5 text-left text-[15px] font-medium transition-colors hover:text-foreground/70 group-data-[state=open]:font-semibold">
-                    {item.question}
-                    <PlusMinus />
-                  </Accordion.Trigger>
-                </Accordion.Header>
-                <Accordion.Content className="accordion-content overflow-hidden">
-                  <p className="pb-4 pr-8 text-sm leading-relaxed text-muted">{item.answer}</p>
-                </Accordion.Content>
-              </Accordion.Item>
-            ))}
-          </Accordion.Root>
+          {faqItems.map((item, i) => (
+            <details
+              key={item.question}
+              name="faq"
+              open={i === 0}
+              className="group px-6 py-1.5 open:bg-background-alt"
+            >
+              <summary className="focus-ring cursor-pointer py-3.5 text-[15px] font-medium">
+                {item.question}
+              </summary>
+              <p className="pb-4 text-sm leading-relaxed text-muted">{item.answer}</p>
+            </details>
+          ))}
         </FadeInUp>
       </div>
     </section>

--- a/www/src/components/sections/Hero.tsx
+++ b/www/src/components/sections/Hero.tsx
@@ -20,7 +20,15 @@ function Clip({
   poster?: string;
 }) {
   return (
-    <video className={`hero-video ${className}`} autoPlay muted loop playsInline poster={poster}>
+    <video
+      className={`hero-video ${className}`}
+      controls
+      muted
+      playsInline
+      preload="metadata"
+      aria-label="Example call footage without audio"
+      poster={poster}
+    >
       <source src={src.webm} type="video/webm" />
       <source src={src.mp4} type="video/mp4" />
     </video>
@@ -52,10 +60,10 @@ function CallWindow({ children }: { children: React.ReactNode }) {
             poster={POSTER}
             className="absolute inset-0 h-full w-full object-cover"
           />
-          <div className="absolute inset-0 bg-gradient-to-t from-black/30 via-transparent to-transparent" />
+          <div className="pointer-events-none absolute inset-0 bg-gradient-to-t from-black/30 via-transparent to-transparent" />
           <div className="absolute left-3 top-3 hidden w-[22%] overflow-hidden rounded-lg shadow-lg ring-1 ring-white/25 sm:block">
             <Clip src={SELF} className="aspect-video w-full object-cover" />
-            <span className="absolute bottom-1.5 left-2 rounded bg-black/45 px-1.5 py-0.5 font-mono text-[9px] text-white/90">
+            <span className="pointer-events-none absolute bottom-1.5 left-2 rounded bg-black/45 px-1.5 py-0.5 font-mono text-[9px] text-white/90">
               You
             </span>
           </div>
@@ -74,9 +82,9 @@ export function Hero() {
       <div className="page-column">
         <FadeInUp>
           <h1 className="mx-auto max-w-3xl text-[42px] font-medium leading-[1.04] tracking-tighter sm:text-6xl lg:text-[76px]">
-            Hard question?
+            Your notes,
             <br />
-            You already know.
+            when you need them.
           </h1>
         </FadeInUp>
 
@@ -85,14 +93,16 @@ export function Hero() {
             <CallWindow>
               <ScriptedOverlay script={HERO_SCRIPT} startElapsed={1483} />
             </CallWindow>
+            <p className="mt-3 text-xs text-muted">
+              Illustrative demo with example documents and guidance.
+            </p>
           </div>
         </FadeInUp>
 
         <FadeInUp delay={0.2}>
           <p className="mx-auto mt-8 max-w-xl text-sm leading-relaxed text-muted">
-            Savvy reads your documents before the meeting, then listens alongside you and whispers
-            what to say, what to avoid, and which file says so. A small card on your Mac. Nothing
-            joins the call.
+            Prepare from your documents, then get suggestions during a conversation. Savvy shows
+            what to say, what to avoid, and the supporting source in a small panel on your Mac.
           </p>
           <div className="mt-6 flex flex-wrap items-center justify-center gap-3">
             <DownloadCTA />

--- a/www/src/components/sections/PodBand.tsx
+++ b/www/src/components/sections/PodBand.tsx
@@ -2,10 +2,6 @@ import type { CSSProperties, ReactNode } from "react";
 import { FadeInUp } from "@/components/animations/FadeInUp";
 import { Eyebrow, TwoLineHeading } from "@/components/sections/primitives";
 
-// The money.x.com stat band: one giant claim with rectangular cards orbiting
-// around it. Cards on the "back" layer slide behind the claim and are blurred;
-// the claim carries a backdrop blur so anything drifting behind it softens.
-
 export type BandPod = {
   key: string;
   /** Position utilities. Author a mobile position first, then md: overrides. */

--- a/www/src/components/sections/Privacy.tsx
+++ b/www/src/components/sections/Privacy.tsx
@@ -9,9 +9,6 @@ import {
   WaveIcon,
 } from "@/components/sections/primitives";
 
-// The README's data table, rendered verbatim in spirit: what stays, what
-// leaves. The meeting-audio row is the one people miss, so it is the one row
-// that carries the danger colour.
 const P = {
   doc: "M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7ZM14 2v4a2 2 0 0 0 2 2h4M10 9H8M16 13H8M16 17H8",
   db: "M12 2C7.6 2 4 3.3 4 5s3.6 3 8 3 8-1.3 8-3-3.6-3-8-3ZM4 5v14c0 1.7 3.6 3 8 3s8-1.3 8-3V5M4 12c0 1.7 3.6 3 8 3s8-1.3 8-3",
@@ -45,28 +42,28 @@ const ROWS = [
   {
     icon: P.doc,
     data: "Documents",
-    local: "Read-only, never copied",
-    sent: "Excerpts, when asked",
+    local: "Source files unchanged",
+    sent: "Selected excerpts for AI tasks",
   },
   { icon: P.db, data: "Indexes", local: "Local SQLite", sent: "Excerpts only" },
   {
     icon: P.mic,
     data: "Meeting audio",
-    local: "Local, 30-day retention",
+    local: "Local; cleaned up at startup after 30 days",
     sent: "Streamed to your transcription provider",
     alert: true,
   },
   {
     icon: P.chat,
     data: "Transcript",
-    local: "Local, 30-day retention",
-    sent: "Recent turns, when asked",
+    local: "Local; cleaned up at startup after 30 days",
+    sent: "Recent turns during guidance",
   },
   {
     icon: P.clipboard,
     data: "Brief",
     local: "Private, versioned",
-    sent: "Whole brief, when asked",
+    sent: "Brief during guidance",
   },
   { icon: P.key, data: "Credentials", local: "macOS Keychain", sent: "Authorization header only" },
 ];
@@ -79,20 +76,20 @@ export function Privacy() {
           <Eyebrow>Local-first</Eyebrow>
           <TwoLineHeading
             className="mt-4"
-            line1="Stays on your Mac"
-            line2="Honest about what doesn't"
+            line1="Know where your data goes"
+            line2="Local storage, external AI providers"
           />
           <p className="mt-6 max-w-md text-sm leading-relaxed text-muted">
-            Documents are read where they live and never copied. Indexes sit in a private local
-            SQLite database that only your account can open. Audio and transcripts are deleted after
-            30 days. The honest part: audio streams to your transcription provider as it is
-            captured, and excerpts plus recent turns go to the model your CLI is signed in to.
+            Source files stay in their folders. Savvy stores extracted text and indexes in a local
+            database. Audio streams to your transcription provider. AI tasks send selected excerpts
+            and relevant context to your model provider. At startup, Savvy removes local recordings
+            and transcripts older than 30 days.
           </p>
           <StatList
             items={[
-              { icon: FolderIcon, label: "Documents referenced read-only, never copied" },
+              { icon: FolderIcon, label: "Source files remain unchanged" },
               { icon: KeyIcon, label: "Provider keys in the macOS Keychain" },
-              { icon: ClockIcon, label: "Audio and transcripts deleted after 30 days" },
+              { icon: ClockIcon, label: "30-day local retention, cleaned up at startup" },
               { icon: WaveIcon, label: "Audio streams only to your transcription provider" },
             ]}
           />

--- a/www/src/components/sections/Reasons.tsx
+++ b/www/src/components/sections/Reasons.tsx
@@ -11,8 +11,6 @@ import {
 } from "@/components/sections/primitives";
 import { REASONS_SCRIPT } from "@/content/scripts";
 
-// Three-column beat (heading | product | body): the behaviour that separates
-// Savvy from copilots that narrate — it is quiet until one of three triggers.
 export function Reasons() {
   return (
     <section id="how" className="scroll-mt-8 py-20 lg:py-28">
@@ -34,21 +32,19 @@ export function Reasons() {
 
         <FadeInUp delay={0.15}>
           <p className="text-sm leading-relaxed text-muted">
-            Most meeting copilots narrate. Savvy waits. The mascot switches to thinking for exactly
-            three reasons: the other side asked a question, someone touched a red line from your
-            brief, or you pressed Advice.
+            Savvy checks questions against your documents, flags constraints from your brief, and
+            offers advice when you ask for it.
           </p>
           <p className="mt-4 text-sm leading-relaxed text-muted">
-            Between those it re-reads your brief and notes against the last minute of conversation
-            and only interrupts with a card labelled Savvy noticed when it has something concrete.
-            No generic coaching, no play-by-play.
+            It also reviews recent conversation for relevant changes. A "Savvy noticed" card appears
+            when it finds something worth raising.
           </p>
           <StatList
             items={[
               { icon: QuestionIcon, label: "Answers their question" },
               { icon: FlagIcon, label: "Flags a red line before you cross it" },
               { icon: SparkIcon, label: "Advice when you ask for it" },
-              { icon: MuteIcon, label: "Silent the rest of the time" },
+              { icon: MuteIcon, label: "Additional insights when relevant" },
             ]}
           />
         </FadeInUp>

--- a/www/src/components/sections/SourceBand.tsx
+++ b/www/src/components/sections/SourceBand.tsx
@@ -1,9 +1,5 @@
 import { type BandPod, PodBand } from "@/components/sections/PodBand";
 
-// The money.x.com stat band, repurposed: recommendation cards drift around one
-// claim, each carrying the file it was grounded in. Same nine anchor
-// positions as the sibling site so the choreography is known-good.
-
 type Pod = {
   key: string;
   title: "Answer" | "Red line" | "Advice" | "Savvy noticed";
@@ -177,11 +173,11 @@ export function SourceBand() {
   return (
     <PodBand
       eyebrow="Grounded"
-      line1="Every card cites a file"
-      line2="Say, avoid, and the page"
+      line1="See the supporting source"
+      line2="Documents, brief, and conversation"
       pods={BAND_PODS}
-      stat="Grounded, not guessed."
-      caption="Every recommendation is built from your own documents and the brief you approved, and shows the file it leaned on."
+      stat="Check the source."
+      caption="Suggestions include supporting context from your documents, brief, or conversation. Review it before acting."
     />
   );
 }

--- a/www/src/components/sections/YourModel.tsx
+++ b/www/src/components/sections/YourModel.tsx
@@ -9,10 +9,6 @@ import {
 } from "@/components/sections/primitives";
 import { ProviderChip } from "@/components/sections/vignettes";
 
-// Savvy has no model of its own — it shells out to the CLI already signed in
-// on the Mac. This is the pricing objection answered before it is asked, so it
-// gets the full three-column treatment with the provider-check chip on top.
-
 function ClaudeMark() {
   return (
     <svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor" aria-hidden="true">
@@ -77,14 +73,14 @@ const ProvidersVignette = (
         <ProviderRow
           mark={<ClaudeMark />}
           name="Claude Code"
-          detail="claude-fable-5 · 1M context"
+          detail="Your signed-in account"
           ready
           active
         />
         <ProviderRow
           mark={<OpenAIMark />}
           name="Codex CLI"
-          detail="gpt-5.6-sol · priority tier"
+          detail="Your signed-in account"
           ready={false}
         />
         <div className="px-3.5 pb-1 pt-3 font-mono text-[10px] uppercase tracking-wider text-[var(--muted)]">
@@ -93,7 +89,7 @@ const ProvidersVignette = (
         <ProviderRow
           mark={<span className="font-mono text-[11px] font-bold">DG</span>}
           name="Deepgram"
-          detail="nova-3 · key in Keychain · mip_opt_out=true"
+          detail="API key stored in Keychain"
           ready
           active
         />
@@ -110,8 +106,8 @@ export function YourModel() {
           <Eyebrow>Bring your own</Eyebrow>
           <TwoLineHeading
             className="mt-4"
-            line1="The CLI you already have"
-            line2="No subscription, no markup"
+            line1="Use your own accounts"
+            line2="Choose your providers"
           />
         </FadeInUp>
 
@@ -123,14 +119,13 @@ export function YourModel() {
 
         <FadeInUp delay={0.15}>
           <p className="text-sm leading-relaxed text-muted">
-            Savvy doesn't run a model of its own. It shells out to Claude Code or the Codex CLI
-            already signed in on your Mac, so recommendations bill to the plan you have and follow
-            the terms you agreed to. Excerpts and recent turns go to that provider under your
-            account, nowhere else.
+            The open-source app uses Claude Code or Codex CLI for guidance. Sign in on your Mac and
+            use your existing provider account. Selected excerpts, your brief, and recent transcript
+            turns are sent to that provider.
           </p>
           <p className="mt-4 text-sm leading-relaxed text-muted">
-            Speech goes through your own Deepgram or AssemblyAI key, stored in the macOS Keychain,
-            with model-training opt-out set where the provider offers it.
+            Transcription uses your Deepgram or AssemblyAI API key, stored in the macOS Keychain.
+            Provider usage is billed separately.
           </p>
           <StatList
             items={[

--- a/www/src/components/sections/primitives.tsx
+++ b/www/src/components/sections/primitives.tsx
@@ -1,9 +1,5 @@
 import type { ReactNode } from "react";
 
-// Shared bits for the money.x.com-style sections: tiny square-bullet eyebrow,
-// two-line heading (ink line + muted line), section hairline, and the
-// icon+label stat rows that sit in section side columns.
-
 /** Section hairline, clipped to the content column so it never runs under
  *  the fixed left rail. */
 export function Divider() {

--- a/www/src/content/faq.ts
+++ b/www/src/content/faq.ts
@@ -1,45 +1,42 @@
-// Every answer here has to be defensible against the app README. Nothing about
-// hiding Savvy from a screen share, nothing the current build cannot do.
-
 export const faqItems = [
   {
     question: "What do I need to run Savvy?",
     answer:
-      "A Mac on macOS 13 or newer with Apple Silicon, plus a Deepgram or AssemblyAI API key for transcription. For recommendations you also need Claude Code or the Codex CLI installed on your PATH and signed in. On first launch Savvy asks for microphone and screen-recording permission; only the microphone is required to finish setup, but without system audio it hears only you.",
+      "An Apple Silicon Mac running macOS 13 or newer, a Deepgram or AssemblyAI API key, and Claude Code or Codex CLI installed and signed in. Allow microphone access to hear you and screen-recording access to capture system audio.",
   },
   {
     question: "Is Savvy free?",
     answer:
-      "Yes. Savvy is open source under the MIT license and there is no paid tier. You pay your own providers: a Deepgram or AssemblyAI account for transcription, and whatever plan the CLI you use for recommendations is signed in to.",
+      "The open-source app is free under the MIT license. You pay your own transcription and model providers for their services.",
   },
   {
     question: "Where does my data go?",
     answer:
-      "Your documents stay where they live. Savvy reads them read-only and never copies them, keeping derived chunks in a private local SQLite database. Meeting audio is streamed to the transcription provider you configure; there is no offline transcription in the current build. At recommendation time, selected excerpts, the brief and recent transcript turns reach the model provider your CLI is signed in to, under your own account. Provider keys sit in the macOS Keychain. Audio and transcripts are deleted after 30 days.",
+      "Source files stay in their folders. Extracted text, indexes, briefs, recordings, and transcripts are stored locally. Audio streams to your transcription provider. AI tasks send selected excerpts and relevant context to the provider your CLI uses. Transcription keys are stored in the macOS Keychain. Local recordings and transcripts older than 30 days are removed when Savvy starts.",
   },
   {
     question: "Does it work with Zoom, Meet, Teams or phone calls?",
     answer:
-      "Yes, with any app that plays audio. Savvy captures system audio through ScreenCaptureKit and your microphone separately, so nothing joins the call and no one sees an extra participant. It needs microphone and screen-recording permission to hear both sides.",
+      "Savvy captures audio played by apps on your Mac, plus your microphone. It does not join the call as a participant. Calls on another device are not captured unless their audio reaches your Mac.",
   },
   {
     question: "Is Savvy hidden from screen share?",
     answer:
-      "No, and it does not try to be. Savvy is a small always-on-top panel that shows up in a screen share like any other window. It is your own notes in the room, not a disguise. Use it where AI assistance is allowed, and check the rules of your meeting first.",
+      "No. The panel can appear when you share your screen, like other windows. Follow the rules of your meeting when using AI assistance.",
   },
   {
     question: "Which languages does it handle?",
     answer:
-      "Transcription language is selectable per model, and multi-language transcription is the default. The response language is a separate setting on the brief, so you can transcribe a Spanish or Catalan conversation and read the guidance in English, or the other way round.",
+      "Available transcription languages depend on the provider and model you select. The response language is a separate setting on your brief, so guidance can use a different language from the conversation.",
   },
   {
-    question: "Why does Savvy sometimes say nothing?",
+    question: "When does Savvy offer guidance?",
     answer:
-      "Because it only speaks up for three reasons: the other side asked a question, someone touched a red line from your brief, or you pressed Advice. Between those it re-reads your brief and notes against the last minute of conversation and shows a Savvy noticed card only when something concrete turns up. With no recommendation CLI signed in it never thinks at all and shows a single notice instead.",
+      "Savvy responds to questions, flags constraints from your brief, and offers advice when you press Advice. It also checks recent conversation for relevant changes. Guidance requires a configured recommendation provider.",
   },
   {
     question: "Does it run on Intel Macs?",
     answer:
-      "Releases are Apple Silicon only, shipped as an aarch64 DMG. Intel is buildable from source but unsupported, so nothing on that path is tested.",
+      "Release downloads support Apple Silicon. Intel builds from source are unsupported and untested.",
   },
 ] as const;

--- a/www/src/lib/consent.ts
+++ b/www/src/lib/consent.ts
@@ -1,0 +1,19 @@
+export const CONSENT_KEY = "savvy.analytics-consent";
+export const CONSENT_YEAR = 365 * 24 * 60 * 60 * 1000;
+
+export function readConsent(
+  raw: string | null,
+  now = Date.now(),
+): { allowed: boolean; expires: number } | null {
+  try {
+    const value = JSON.parse(raw || "null");
+    return typeof value?.allowed === "boolean" &&
+      Number.isFinite(value.expires) &&
+      value.expires > now &&
+      value.expires <= now + CONSENT_YEAR
+      ? { allowed: value.allowed, expires: value.expires }
+      : null;
+  } catch {
+    return null;
+  }
+}

--- a/www/src/lib/constants.ts
+++ b/www/src/lib/constants.ts
@@ -1,8 +1,6 @@
 export const SITE_NAME = "Savvy";
 export const COMPANY_NAME = "Alamas Labs";
-// TODO: swap for the real domain before the first deploy. Used for canonical
-// URLs, Open Graph and the sitemap.
-export const SITE_URL = "https://jamalavedra.github.io/savvy";
+export const SITE_URL = "https://savvycopilot.com";
 
 export const REPO_URL = "https://github.com/jamalavedra/savvy";
 

--- a/www/wrangler.jsonc
+++ b/www/wrangler.jsonc
@@ -4,5 +4,11 @@
   "assets": {
     "directory": "./out",
     "not_found_handling": "404-page"
-  }
+  },
+  "routes": [
+    {
+      "pattern": "savvycopilot.com",
+      "custom_domain": true
+    }
+  ]
 }

--- a/www/wrangler.jsonc
+++ b/www/wrangler.jsonc
@@ -1,0 +1,8 @@
+{
+  "name": "savvy-www",
+  "compatibility_date": "2026-08-28",
+  "assets": {
+    "directory": "./out",
+    "not_found_handling": "404-page"
+  }
+}


### PR DESCRIPTION
The landing page introduced in #9 overstated local-only storage and 30-day deletion, promised there would be no paid tier, and shipped two libraries for simple presentation. This follow-up describes the released BYOK app, including extracted text stored locally, provider data sharing, and retention cleanup at startup.

- Replace Radix FAQ components with native HTML details and Framer Motion entrances with CSS; remove both dependencies.
- Rewrite promotional copy and provider descriptions, label the illustrative demo, and use manual video controls.
- Add opt-in Umami analytics for savvycopilot.com, with allow/reject controls and withdrawal. Validate consent records and keep the tracker out of initial HTML.
- Publish /privacy/ using the Alamas Labs operator and hello@savvycopilot.com privacy contact, with Savvy-specific data handling and a footer link.
- Set canonical/social URLs to the purchased savvycopilot.com domain.
- Keep the website Node smoke check out of the desktop Vitest runner.
- Add Cloudflare static-assets configuration, pinned Wrangler commands, and website CI with an export smoke check. No server runtime or automated deployment.

Validation: all 44 desktop tests, frozen install, Biome, Next production build (including TypeScript), Node export smoke test, Wrangler deploy dry run, and local Wrangler HTTP checks for the homepage, 17 assets, robots.txt, sitemap, and 404 responses all pass. Workflow formatting also passes. Interactive consent verification was blocked because Hot Desk was reserved by another task. Consent validation and live HTML checks pass.

Deployed to https://savvycopilot.com in the confirmed Openfort account using Wrangler. Version: 73971a8d-0f1f-4a16-9081-c8ce9672c025. Live HTTPS, referenced assets, canonical metadata, robots.txt, sitemap, and HTTP 404 checks pass. The account ID is passed at deployment, not stored in the repository. The original worktree's uncommitted managed-service changes are untouched.
