### PR TITLE
feat(www): centre the hero and add a Windows availability notice

### DIFF
--- a/www/smoke.test.mjs
+++ b/www/smoke.test.mjs
@@ -9,6 +9,8 @@ test("static export has metadata, FAQ answers and referenced assets", async () =
   const html = await readFile("out/index.html", "utf8");
   assert.match(html, /rel="canonical" href="https:\/\/savvycopilot\.com\/"/);
   assert.equal([...html.matchAll(/<details[ >]/g)].length, 8);
+  assert.match(html, /<button[^>]*disabled=""[^>]*>.*?Windows coming soon<\/button>/);
+  assert.equal([...html.matchAll(/Reads your files first\.<br\//g)].length, 1);
   assert.match(html, /<summary[^>]*>Where does my data go\?/);
   for (const [, asset] of html.matchAll(/(?:src|poster)="(\/[^"?]+)"/g)) {
     await access(`out${asset}`);

--- a/www/src/app/globals.css
+++ b/www/src/app/globals.css
@@ -25,7 +25,6 @@
   /* Fonts */
   --font-sans: var(--font-inter);
   --font-mono: var(--font-jetbrains-mono);
-  /* Marketing only: the handwritten margin note beside the hero. */
   --font-hand: var(--font-caveat), ui-rounded, cursive;
 
   /* Easing */

--- a/www/src/app/globals.css
+++ b/www/src/app/globals.css
@@ -25,6 +25,8 @@
   /* Fonts */
   --font-sans: var(--font-inter);
   --font-mono: var(--font-jetbrains-mono);
+  /* Marketing only: the handwritten margin note beside the hero. */
+  --font-hand: var(--font-caveat), ui-rounded, cursive;
 
   /* Easing */
   --ease-smooth: cubic-bezier(0.25, 0.1, 0.35, 1);

--- a/www/src/app/layout.tsx
+++ b/www/src/app/layout.tsx
@@ -38,12 +38,7 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: Readonly<{ children: React.ReactNode }>) {
   return (
-    // The font variables live on <html>, not <body>: Tailwind's `@theme`
-    // declares tokens like `--font-hand: var(--font-caveat), …` on :root, and
-    // a var() nested inside a custom property is resolved where that property
-    // is DECLARED. With the faces only on <body>, every such token resolved
-    // against an undefined variable and the utility silently fell back to the
-    // inherited family.
+    // Tailwind resolves font tokens on :root, so the font variables belong on <html>.
     <html lang="en" className={`${inter.variable} ${jetbrainsMono.variable} ${caveat.variable}`}>
       <body>
         {children}

--- a/www/src/app/layout.tsx
+++ b/www/src/app/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import { Analytics } from "@/components/Analytics";
 import { SITE_URL } from "@/lib/constants";
-import { inter, jetbrainsMono } from "@/lib/fonts";
+import { caveat, inter, jetbrainsMono } from "@/lib/fonts";
 import "./globals.css";
 
 const TITLE = "Savvy | AI guidance from your documents, on your Mac";
@@ -38,8 +38,14 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: Readonly<{ children: React.ReactNode }>) {
   return (
-    <html lang="en">
-      <body className={`${inter.variable} ${jetbrainsMono.variable}`}>
+    // The font variables live on <html>, not <body>: Tailwind's `@theme`
+    // declares tokens like `--font-hand: var(--font-caveat), …` on :root, and
+    // a var() nested inside a custom property is resolved where that property
+    // is DECLARED. With the faces only on <body>, every such token resolved
+    // against an undefined variable and the utility silently fell back to the
+    // inherited family.
+    <html lang="en" className={`${inter.variable} ${jetbrainsMono.variable} ${caveat.variable}`}>
+      <body>
         {children}
         <Analytics />
       </body>

--- a/www/src/components/layout/Rail.tsx
+++ b/www/src/components/layout/Rail.tsx
@@ -1,8 +1,8 @@
 import Link from "next/link";
 import { Header } from "@/components/layout/Header";
 import { Wordmark } from "@/components/layout/Wordmark";
-import { DownloadCTA } from "@/components/ui/DownloadCTA";
-import { NAV, REPO_URL } from "@/lib/constants";
+import { DownloadCTA, GitHubCTA } from "@/components/ui/DownloadCTA";
+import { NAV } from "@/lib/constants";
 
 export function Rail({ active = "/" }: { active?: string }) {
   return (
@@ -28,17 +28,10 @@ export function Rail({ active = "/" }: { active?: string }) {
               {item.label}
             </Link>
           ))}
-          <a
-            href={REPO_URL}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-muted transition-colors hover:text-foreground"
-          >
-            GitHub ↗
-          </a>
         </nav>
-        <div className="fixed bottom-8 left-8 z-40">
+        <div className="fixed bottom-8 left-8 z-40 flex flex-col items-start gap-2.5">
           <DownloadCTA size="sm" />
+          <GitHubCTA />
         </div>
       </div>
       <div className="xl:hidden">

--- a/www/src/components/sections/Hero.tsx
+++ b/www/src/components/sections/Hero.tsx
@@ -86,61 +86,41 @@ function CallStage({ children }: { children: React.ReactNode }) {
   );
 }
 
-/**
- * The margin note: two handwritten lines and an arrow back to the call. It
- * hangs in the gutter beside the frame from xl, where the content column
- * leaves room for it, and sits under the frame below that — so each direction
- * gets its own path rather than a rotated one (rotation clips inside the
- * viewBox).
- */
-const NOTE = ["Reads your files first.", "Then whispers, mid-call."];
-
-const sketch = {
-  fill: "none",
-  stroke: "currentColor",
-  strokeWidth: 1.5,
-  strokeLinecap: "round",
-  strokeLinejoin: "round",
-} as const;
-
-function MarginNote({ side }: { side: "right" | "below" }) {
-  const lines = (
-    <p className="font-hand text-[20px] leading-[1.25] text-muted">
-      {NOTE[0]}
-      <br />
-      {NOTE[1]}
-    </p>
-  );
-
-  if (side === "below") {
-    return (
-      <div className="mx-auto mt-8 max-w-xs text-center xl:hidden">
-        <svg
-          className="hr-arrow mx-auto h-12 w-14 text-muted"
-          viewBox="0 0 56 48"
-          aria-hidden="true"
-          {...sketch}
-        >
-          <path d="M17 45c11-3 17-13 17-27 0-4-.5-8-1-12" />
-          <path d="M26 9 33 2l7 8" />
-        </svg>
-        {lines}
-      </div>
-    );
-  }
-
+// Keep the note below the frame until the right gutter can fit it.
+function MarginNote() {
   return (
-    <div className="pointer-events-none absolute left-full top-8 hidden w-[210px] pl-4 xl:block">
+    <div className="mx-auto mt-8 max-w-xs text-center min-[1360px]:absolute min-[1360px]:left-full min-[1360px]:top-8 min-[1360px]:mt-0 min-[1360px]:w-[210px] min-[1360px]:pl-4 min-[1360px]:text-left">
       <svg
-        className="hr-arrow h-14 w-24 text-muted"
+        className="hr-arrow mx-auto h-12 w-14 text-muted min-[1360px]:hidden"
+        viewBox="0 0 56 48"
+        aria-hidden="true"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <path d="M17 45c11-3 17-13 17-27 0-4-.5-8-1-12" />
+        <path d="M26 9 33 2l7 8" />
+      </svg>
+      <svg
+        className="hr-arrow hidden h-14 w-24 text-muted min-[1360px]:block"
         viewBox="0 0 96 56"
         aria-hidden="true"
-        {...sketch}
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
       >
         <path d="M92 4c-2 20-14 33-34 38-9 2-19 3-30 2" />
         <path d="M37 36 27 44l11 7" />
       </svg>
-      <div className="mt-1">{lines}</div>
+      <p className="mt-1 font-hand text-[20px] leading-[1.25] text-muted">
+        Reads your files first.
+        <br />
+        Then suggests what to say.
+      </p>
     </div>
   );
 }
@@ -157,17 +137,13 @@ export function Hero() {
           </h1>
         </FadeInUp>
 
-        {/* The call frame is the hero: centred on the page, with the note
-            hanging in the gutter beside it rather than claiming a column of
-            its own, so the composition stays symmetrical. */}
         <FadeInUp delay={0.1}>
           <div className="relative mx-auto mt-10 w-full max-w-[680px]">
-            <MarginNote side="right" />
             <CallStage>
               <ScriptedOverlay script={HERO_SCRIPT} startElapsed={1483} />
             </CallStage>
+            <MarginNote />
           </div>
-          <MarginNote side="below" />
         </FadeInUp>
 
         <FadeInUp delay={0.2}>

--- a/www/src/components/sections/Hero.tsx
+++ b/www/src/components/sections/Hero.tsx
@@ -1,9 +1,9 @@
 import { FadeInUp } from "@/components/animations/FadeInUp";
 import { ScriptedOverlay } from "@/components/overlay/OverlayCard";
 import { iconProps, MicIcon } from "@/components/overlay/pieces";
-import { DownloadCTA } from "@/components/ui/DownloadCTA";
+import { DownloadCTA, WindowsSoon } from "@/components/ui/DownloadCTA";
 import { HERO_SCRIPT } from "@/content/scripts";
-import { REPO_URL, REQUIREMENTS } from "@/lib/constants";
+import { REQUIREMENTS } from "@/lib/constants";
 import "./hero.css";
 
 // Footage: Mixkit clip 10457, Mixkit License, re-encoded as a loop.
@@ -86,39 +86,62 @@ function CallStage({ children }: { children: React.ReactNode }) {
   );
 }
 
-/** Hand-drawn arrows from the note to the panel: it sits beside the call on
- *  wide screens and under it on narrow ones, so each direction gets its own
- *  path rather than a rotated one (rotation clips inside the viewBox). */
-function Arrow() {
+/**
+ * The margin note: two handwritten lines and an arrow back to the call. It
+ * hangs in the gutter beside the frame from xl, where the content column
+ * leaves room for it, and sits under the frame below that — so each direction
+ * gets its own path rather than a rotated one (rotation clips inside the
+ * viewBox).
+ */
+const NOTE = ["Reads your files first.", "Then whispers, mid-call."];
+
+const sketch = {
+  fill: "none",
+  stroke: "currentColor",
+  strokeWidth: 1.5,
+  strokeLinecap: "round",
+  strokeLinejoin: "round",
+} as const;
+
+function MarginNote({ side }: { side: "right" | "below" }) {
+  const lines = (
+    <p className="font-hand text-[20px] leading-[1.25] text-muted">
+      {NOTE[0]}
+      <br />
+      {NOTE[1]}
+    </p>
+  );
+
+  if (side === "below") {
+    return (
+      <div className="mx-auto mt-8 max-w-xs text-center xl:hidden">
+        <svg
+          className="hr-arrow mx-auto h-12 w-14 text-muted"
+          viewBox="0 0 56 48"
+          aria-hidden="true"
+          {...sketch}
+        >
+          <path d="M17 45c11-3 17-13 17-27 0-4-.5-8-1-12" />
+          <path d="M26 9 33 2l7 8" />
+        </svg>
+        {lines}
+      </div>
+    );
+  }
+
   return (
-    <>
+    <div className="pointer-events-none absolute left-full top-8 hidden w-[210px] pl-4 xl:block">
       <svg
-        className="hr-arrow mx-auto h-16 w-16 text-muted lg:hidden"
-        viewBox="0 0 64 64"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="1.6"
-        strokeLinecap="round"
-        strokeLinejoin="round"
+        className="hr-arrow h-14 w-24 text-muted"
+        viewBox="0 0 96 56"
         aria-hidden="true"
+        {...sketch}
       >
-        <path d="M20 58c14-4 21-14 22-30 0-6-1-12-2-18" />
-        <path d="M32 16 40 8l8 9" />
+        <path d="M92 4c-2 20-14 33-34 38-9 2-19 3-30 2" />
+        <path d="M37 36 27 44l11 7" />
       </svg>
-      <svg
-        className="hr-arrow hidden text-muted lg:block lg:h-20 lg:w-24"
-        viewBox="0 0 96 80"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="1.6"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        aria-hidden="true"
-      >
-        <path d="M86 6c4 26-6 44-30 52-10 3-21 4-33 3" />
-        <path d="M31 51 23 61l12 6" />
-      </svg>
-    </>
+      <div className="mt-1">{lines}</div>
+    </div>
   );
 }
 
@@ -134,51 +157,30 @@ export function Hero() {
           </h1>
         </FadeInUp>
 
+        {/* The call frame is the hero: centred on the page, with the note
+            hanging in the gutter beside it rather than claiming a column of
+            its own, so the composition stays symmetrical. */}
         <FadeInUp delay={0.1}>
-          <div className="mt-10 flex flex-col items-center gap-6 lg:flex-row lg:items-center lg:gap-8">
-            <div className="w-full min-w-0 lg:flex-1">
-              <CallStage>
-                <ScriptedOverlay script={HERO_SCRIPT} startElapsed={1483} />
-              </CallStage>
-            </div>
-
-            <div className="max-w-sm shrink-0 text-center lg:w-60 lg:text-left xl:w-64">
-              <Arrow />
-              <p className="mt-1 text-sm leading-relaxed text-muted">
-                Prepare from your documents, then get suggestions during a conversation. Savvy shows
-                what to say, what to avoid, and the supporting source in a small panel on your Mac.
-              </p>
-              <p className="mt-3 text-xs text-muted">
-                Illustrative demo with example documents and guidance.
-              </p>
-            </div>
+          <div className="relative mx-auto mt-10 w-full max-w-[680px]">
+            <MarginNote side="right" />
+            <CallStage>
+              <ScriptedOverlay script={HERO_SCRIPT} startElapsed={1483} />
+            </CallStage>
           </div>
+          <MarginNote side="below" />
         </FadeInUp>
 
         <FadeInUp delay={0.2}>
           <div className="mt-10 flex flex-wrap items-center justify-center gap-3">
             <DownloadCTA />
-            <a
-              href={REPO_URL}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="focus-ring inline-flex items-center gap-2 rounded-full border border-border px-5 py-2.5 text-sm font-semibold transition-colors hover:bg-background-alt"
-            >
-              <GitHubIcon />
-              View on GitHub
-            </a>
+            <WindowsSoon />
           </div>
           <p className="mt-4 text-center font-mono text-[11px] text-muted">{REQUIREMENTS}</p>
+          <p className="mt-2 text-center text-xs text-muted">
+            Illustrative demo with example documents and guidance.
+          </p>
         </FadeInUp>
       </div>
     </section>
-  );
-}
-
-function GitHubIcon({ size = 14 }: { size?: number }) {
-  return (
-    <svg aria-hidden="true" width={size} height={size} viewBox="0 0 24 24" fill="currentColor">
-      <path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.1.79-.25.79-.56v-2.17c-3.2.7-3.87-1.36-3.87-1.36-.52-1.33-1.28-1.68-1.28-1.68-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.19 1.76 1.19 1.03 1.76 2.7 1.25 3.36.96.1-.75.4-1.25.73-1.54-2.55-.29-5.24-1.28-5.24-5.68 0-1.26.45-2.28 1.19-3.09-.12-.29-.52-1.46.11-3.05 0 0 .97-.31 3.18 1.18a11 11 0 0 1 5.78 0c2.2-1.49 3.17-1.18 3.17-1.18.63 1.59.24 2.76.12 3.05.74.81 1.19 1.83 1.19 3.09 0 4.41-2.69 5.38-5.25 5.67.41.36.78 1.06.78 2.14v3.17c0 .31.21.67.8.56A11.5 11.5 0 0 0 23.5 12C23.5 5.65 18.35.5 12 .5Z" />
-    </svg>
   );
 }

--- a/www/src/components/ui/DownloadCTA.tsx
+++ b/www/src/components/ui/DownloadCTA.tsx
@@ -1,4 +1,4 @@
-import { LINKS } from "@/lib/constants";
+import { LINKS, REPO_URL } from "@/lib/constants";
 
 function AppleIcon({ size = 14 }: { size?: number }) {
   return (
@@ -20,6 +20,58 @@ export function DownloadCTA({ size = "md" }: { size?: "md" | "sm" }) {
     >
       <AppleIcon size={size === "sm" ? 12 : 14} />
       Download for Mac
+    </a>
+  );
+}
+
+export function WindowsIcon({ size = 14 }: { size?: number }) {
+  return (
+    <svg aria-hidden="true" width={size} height={size} viewBox="0 0 18 18" fill="currentColor">
+      <path d="M0 2.55 7.35 1.55v6.9H0V2.55ZM8.25 1.42 18 0v8.45H8.25V1.42ZM0 9.55h7.35v6.9L0 15.45v-5.9ZM8.25 9.55H18V18l-9.75-1.42V9.55Z" />
+    </svg>
+  );
+}
+
+/**
+ * Windows is being built (jamalavedra/savvy#15) but there is nothing to
+ * download yet, so this is a genuinely disabled control rather than a link
+ * that goes nowhere — screen readers get told, and nothing is clickable.
+ */
+export function WindowsSoon({ size = "md" }: { size?: "md" | "sm" }) {
+  return (
+    <button
+      type="button"
+      disabled
+      className={`inline-flex cursor-not-allowed items-center justify-center gap-2 rounded-full border border-border font-semibold text-muted ${
+        size === "sm" ? "px-4 py-2 text-[13px]" : "px-5 py-2.5 text-sm"
+      }`}
+    >
+      <WindowsIcon size={size === "sm" ? 12 : 14} />
+      Windows — coming soon
+    </button>
+  );
+}
+
+export function GitHubIcon({ size = 14 }: { size?: number }) {
+  return (
+    <svg aria-hidden="true" width={size} height={size} viewBox="0 0 24 24" fill="currentColor">
+      <path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.1.79-.25.79-.56v-2.17c-3.2.7-3.87-1.36-3.87-1.36-.52-1.33-1.28-1.68-1.28-1.68-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.19 1.76 1.19 1.03 1.76 2.7 1.25 3.36.96.1-.75.4-1.25.73-1.54-2.55-.29-5.24-1.28-5.24-5.68 0-1.26.45-2.28 1.19-3.09-.12-.29-.52-1.46.11-3.05 0 0 .97-.31 3.18 1.18a11 11 0 0 1 5.78 0c2.2-1.49 3.17-1.18 3.17-1.18.63 1.59.24 2.76.12 3.05.74.81 1.19 1.83 1.19 3.09 0 4.41-2.69 5.38-5.25 5.67.41.36.78 1.06.78 2.14v3.17c0 .31.21.67.8.56A11.5 11.5 0 0 0 23.5 12C23.5 5.65 18.35.5 12 .5Z" />
+    </svg>
+  );
+}
+
+/** The repo, as a button — it lives in the rail rather than the hero, where
+ *  it competed with the download. */
+export function GitHubCTA() {
+  return (
+    <a
+      href={REPO_URL}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="focus-ring inline-flex items-center justify-center gap-2 rounded-full border border-border px-4 py-2 text-[13px] font-semibold transition-colors hover:bg-background-alt"
+    >
+      <GitHubIcon size={12} />
+      View on GitHub
     </a>
   );
 }

--- a/www/src/components/ui/DownloadCTA.tsx
+++ b/www/src/components/ui/DownloadCTA.tsx
@@ -24,7 +24,7 @@ export function DownloadCTA({ size = "md" }: { size?: "md" | "sm" }) {
   );
 }
 
-export function WindowsIcon({ size = 14 }: { size?: number }) {
+function WindowsIcon({ size = 14 }: { size?: number }) {
   return (
     <svg aria-hidden="true" width={size} height={size} viewBox="0 0 18 18" fill="currentColor">
       <path d="M0 2.55 7.35 1.55v6.9H0V2.55ZM8.25 1.42 18 0v8.45H8.25V1.42ZM0 9.55h7.35v6.9L0 15.45v-5.9ZM8.25 9.55H18V18l-9.75-1.42V9.55Z" />
@@ -32,27 +32,20 @@ export function WindowsIcon({ size = 14 }: { size?: number }) {
   );
 }
 
-/**
- * Windows is being built (jamalavedra/savvy#15) but there is nothing to
- * download yet, so this is a genuinely disabled control rather than a link
- * that goes nowhere — screen readers get told, and nothing is clickable.
- */
-export function WindowsSoon({ size = "md" }: { size?: "md" | "sm" }) {
+export function WindowsSoon() {
   return (
     <button
       type="button"
       disabled
-      className={`inline-flex cursor-not-allowed items-center justify-center gap-2 rounded-full border border-border font-semibold text-muted ${
-        size === "sm" ? "px-4 py-2 text-[13px]" : "px-5 py-2.5 text-sm"
-      }`}
+      className="inline-flex cursor-not-allowed items-center justify-center gap-2 rounded-full border border-border px-5 py-2.5 text-sm font-semibold text-muted"
     >
-      <WindowsIcon size={size === "sm" ? 12 : 14} />
-      Windows — coming soon
+      <WindowsIcon />
+      Windows coming soon
     </button>
   );
 }
 
-export function GitHubIcon({ size = 14 }: { size?: number }) {
+function GitHubIcon({ size = 14 }: { size?: number }) {
   return (
     <svg aria-hidden="true" width={size} height={size} viewBox="0 0 24 24" fill="currentColor">
       <path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.1.79-.25.79-.56v-2.17c-3.2.7-3.87-1.36-3.87-1.36-.52-1.33-1.28-1.68-1.28-1.68-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.19 1.76 1.19 1.03 1.76 2.7 1.25 3.36.96.1-.75.4-1.25.73-1.54-2.55-.29-5.24-1.28-5.24-5.68 0-1.26.45-2.28 1.19-3.09-.12-.29-.52-1.46.11-3.05 0 0 .97-.31 3.18 1.18a11 11 0 0 1 5.78 0c2.2-1.49 3.17-1.18 3.17-1.18.63 1.59.24 2.76.12 3.05.74.81 1.19 1.83 1.19 3.09 0 4.41-2.69 5.38-5.25 5.67.41.36.78 1.06.78 2.14v3.17c0 .31.21.67.8.56A11.5 11.5 0 0 0 23.5 12C23.5 5.65 18.35.5 12 .5Z" />
@@ -60,8 +53,6 @@ export function GitHubIcon({ size = 14 }: { size?: number }) {
   );
 }
 
-/** The repo, as a button — it lives in the rail rather than the hero, where
- *  it competed with the download. */
 export function GitHubCTA() {
   return (
     <a

--- a/www/src/lib/fonts.ts
+++ b/www/src/lib/fonts.ts
@@ -1,4 +1,4 @@
-import { Inter, JetBrains_Mono } from "next/font/google";
+import { Caveat, Inter, JetBrains_Mono } from "next/font/google";
 
 // Inter is the app's UI face (savvy/src/App.css); the mono is for eyebrows,
 // file paths and numerals only.
@@ -11,5 +11,12 @@ export const inter = Inter({
 export const jetbrainsMono = JetBrains_Mono({
   subsets: ["latin"],
   variable: "--font-jetbrains-mono",
+  display: "swap",
+});
+
+// The one hand-annotation voice: the margin note beside the hero, nothing else.
+export const caveat = Caveat({
+  subsets: ["latin"],
+  variable: "--font-caveat",
   display: "swap",
 });

--- a/www/src/lib/fonts.ts
+++ b/www/src/lib/fonts.ts
@@ -14,7 +14,6 @@ export const jetbrainsMono = JetBrains_Mono({
   display: "swap",
 });
 
-// The one hand-annotation voice: the margin note beside the hero, nothing else.
 export const caveat = Caveat({
   subsets: ["latin"],
   variable: "--font-caveat",


### PR DESCRIPTION
Centre the call frame in the content column and add a handwritten note. The note sits below the frame on smaller screens and moves beside it at 1360px, where it fits without clipping.

Move the GitHub button to the desktop rail and add a disabled Windows coming soon button beside the Mac download. Keep the demo disclaimer under the requirements. Put font variables on the HTML element so Tailwind resolves the font families correctly.

Review fixes remove duplicate note markup, unused button sizing, and verbose comments. The note now says "Then suggests what to say" to describe the on-screen guidance.

Validation: lint, typecheck, production build, four smoke tests, and Wrangler deployment dry run pass. Browser checks pass at ten widths from 320px to 1920px, including the 1280px clipping regression, with Caveat loaded and the Windows button disabled.
